### PR TITLE
feat: add support for --all-namespaces (-A)

### DIFF
--- a/pkg/api/cephr.go
+++ b/pkg/api/cephr.go
@@ -61,6 +61,7 @@ func (c *cephrStore) List(ctx context.Context, options *metainternalversion.List
 		// 	fieldSelector = options.FieldSelector
 		// }
 	}
+	klog.Infof("listing cluster ephemeral reports")
 	list, err := c.listCephr()
 	if err != nil {
 		return nil, errors.NewBadRequest("failed to list resource clusterephemeralreport")
@@ -86,6 +87,7 @@ func (c *cephrStore) List(ctx context.Context, options *metainternalversion.List
 }
 
 func (c *cephrStore) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	klog.Infof("getting cluster ephemeral reports name=%s", name)
 	report, err := c.getCephr(name)
 	if err != nil || report == nil {
 		return nil, errors.NewNotFound(reportsv1.Resource("clusterephemeralreports"), name)
@@ -115,6 +117,7 @@ func (c *cephrStore) Create(ctx context.Context, obj runtime.Object, createValid
 		return nil, errors.NewBadRequest("failed to validate cluster ephemeral report")
 	}
 
+	klog.Infof("creating cluster ephemeral reports name=%s", cephr.Name)
 	if !isDryRun {
 		if err := c.createCephr(cephr); err != nil {
 			return nil, errors.NewBadRequest(fmt.Sprintf("cannot create cluster ephemeral report: %s", err.Error()))
@@ -171,8 +174,9 @@ func (c *cephrStore) Update(ctx context.Context, name string, objInfo rest.Updat
 		return nil, false, errors.NewBadRequest("failed to validate cluster ephemeral report")
 	}
 
+	klog.Infof("updating cluster ephemeral reports name=%s", cephr.Name)
 	if !isDryRun {
-		if err := c.createCephr(cephr); err != nil {
+		if err := c.updateCephr(cephr, false); err != nil {
 			return nil, false, errors.NewBadRequest(fmt.Sprintf("cannot create cluster ephemeral report: %s", err.Error()))
 		}
 		if err := c.broadcaster.Action(watch.Modified, updatedObject); err != nil {
@@ -198,6 +202,7 @@ func (c *cephrStore) Delete(ctx context.Context, name string, deleteValidation r
 		return nil, false, errors.NewBadRequest(fmt.Sprintf("invalid resource: %s", err.Error()))
 	}
 
+	klog.Infof("deleting cluster ephemeral reports name=%s", cephr.Name)
 	if !isDryRun {
 		if err = c.deleteCephr(cephr); err != nil {
 			klog.ErrorS(err, "failed to delete cephr", "name", name)

--- a/pkg/api/cpolr.go
+++ b/pkg/api/cpolr.go
@@ -61,6 +61,7 @@ func (c *cpolrStore) List(ctx context.Context, options *metainternalversion.List
 		// 	fieldSelector = options.FieldSelector
 		// }
 	}
+	klog.Infof("listing all cluster policy reports")
 	list, err := c.listCpolr()
 	if err != nil {
 		return nil, errors.NewBadRequest("failed to list resource clusterpolicyreport")
@@ -86,6 +87,7 @@ func (c *cpolrStore) List(ctx context.Context, options *metainternalversion.List
 }
 
 func (c *cpolrStore) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	klog.Infof("fetching cluster policy report name=%s", name)
 	report, err := c.getCpolr(name)
 	if err != nil || report == nil {
 		return nil, errors.NewNotFound(v1alpha2.Resource("clusterpolicyreports"), name)
@@ -115,6 +117,7 @@ func (c *cpolrStore) Create(ctx context.Context, obj runtime.Object, createValid
 		return nil, errors.NewBadRequest("failed to validate cluster policy report")
 	}
 
+	klog.Infof("creating cluster policy report name=%s", cpolr.Name)
 	if !isDryRun {
 		if err := c.createCpolr(cpolr); err != nil {
 			return nil, errors.NewBadRequest(fmt.Sprintf("cannot create cluster policy report: %s", err.Error()))
@@ -171,8 +174,9 @@ func (c *cpolrStore) Update(ctx context.Context, name string, objInfo rest.Updat
 		return nil, false, errors.NewBadRequest("failed to validate cluster policy report")
 	}
 
+	klog.Infof("updating cluster policy report name=%s", cpolr.Name)
 	if !isDryRun {
-		if err := c.createCpolr(cpolr); err != nil {
+		if err := c.updateCpolr(cpolr, false); err != nil {
 			return nil, false, errors.NewBadRequest(fmt.Sprintf("cannot create cluster policy report: %s", err.Error()))
 		}
 		if err := c.broadcaster.Action(watch.Modified, updatedObject); err != nil {
@@ -198,6 +202,7 @@ func (c *cpolrStore) Delete(ctx context.Context, name string, deleteValidation r
 		return nil, false, errors.NewBadRequest(fmt.Sprintf("invalid resource: %s", err.Error()))
 	}
 
+	klog.Infof("deleting cluster policy report name=%s", cpolr.Name)
 	if !isDryRun {
 		if err = c.deleteCpolr(cpolr); err != nil {
 			klog.ErrorS(err, "failed to delete cpolr", "name", name)

--- a/pkg/api/ephr.go
+++ b/pkg/api/ephr.go
@@ -63,6 +63,8 @@ func (p *ephrStore) List(ctx context.Context, options *metainternalversion.ListO
 		// }
 	}
 	namespace := genericapirequest.NamespaceValue(ctx)
+
+	klog.Infof("listing ephemeral reports for namespace=%s", namespace)
 	list, err := p.listEphr(namespace)
 	if err != nil {
 		return nil, errors.NewBadRequest("failed to list resource ephemeralreport")
@@ -89,6 +91,8 @@ func (p *ephrStore) List(ctx context.Context, options *metainternalversion.ListO
 
 func (p *ephrStore) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	namespace := genericapirequest.NamespaceValue(ctx)
+
+	klog.Infof("getting ephemeral reports name=%s namespace=%s", name, namespace)
 	report, err := p.getEphr(name, namespace)
 	if err != nil || report == nil {
 		return nil, errors.NewNotFound(reportsv1.Resource("ephemeralreports"), name)
@@ -119,10 +123,12 @@ func (p *ephrStore) Create(ctx context.Context, obj runtime.Object, createValida
 	}
 
 	namespace := genericapirequest.NamespaceValue(ctx)
+
 	if len(ephr.Namespace) == 0 {
 		ephr.Namespace = namespace
 	}
 
+	klog.Infof("creating ephemeral reports name=%s namespace=%s", ephr.Name, ephr.Namespace)
 	if !isDryRun {
 		err := p.createEphr(ephr)
 		if err != nil {
@@ -185,6 +191,7 @@ func (p *ephrStore) Update(ctx context.Context, name string, objInfo rest.Update
 		ephr.Namespace = namespace
 	}
 
+	klog.Infof("updating ephemeral reports name=%s namespace=%s", ephr.Name, ephr.Namespace)
 	if !isDryRun {
 		err := p.updateEphr(ephr, false)
 		if err != nil {
@@ -214,6 +221,7 @@ func (p *ephrStore) Delete(ctx context.Context, name string, deleteValidation re
 		return nil, false, errors.NewBadRequest(fmt.Sprintf("invalid resource: %s", err.Error()))
 	}
 
+	klog.Infof("deleting ephemeral reports name=%s namespace=%s", ephr.Name, ephr.Namespace)
 	if !isDryRun {
 		err = p.deleteEphr(ephr)
 		if err != nil {

--- a/pkg/api/polr.go
+++ b/pkg/api/polr.go
@@ -63,6 +63,8 @@ func (p *polrStore) List(ctx context.Context, options *metainternalversion.ListO
 		// }
 	}
 	namespace := genericapirequest.NamespaceValue(ctx)
+
+	klog.Infof("listing policy reports for namespace=%s", namespace)
 	list, err := p.listPolr(namespace)
 	if err != nil {
 		return nil, errors.NewBadRequest("failed to list resource policyreport")
@@ -89,6 +91,8 @@ func (p *polrStore) List(ctx context.Context, options *metainternalversion.ListO
 
 func (p *polrStore) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	namespace := genericapirequest.NamespaceValue(ctx)
+
+	klog.Infof("getting policy reports name=%s namespace=%s", name, namespace)
 	report, err := p.getPolr(name, namespace)
 	if err != nil || report == nil {
 		return nil, errors.NewNotFound(v1alpha2.Resource("policyreports"), name)
@@ -119,10 +123,12 @@ func (p *polrStore) Create(ctx context.Context, obj runtime.Object, createValida
 	}
 
 	namespace := genericapirequest.NamespaceValue(ctx)
+
 	if len(polr.Namespace) == 0 {
 		polr.Namespace = namespace
 	}
 
+	klog.Infof("creating policy reports name=%s namespace=%s", polr.Name, polr.Namespace)
 	if !isDryRun {
 		err := p.createPolr(polr)
 		if err != nil {
@@ -185,6 +191,7 @@ func (p *polrStore) Update(ctx context.Context, name string, objInfo rest.Update
 		polr.Namespace = namespace
 	}
 
+	klog.Infof("updating policy reports name=%s namespace=%s", polr.Name, polr.Namespace)
 	if !isDryRun {
 		err := p.updatePolr(polr, false)
 		if err != nil {
@@ -214,6 +221,7 @@ func (p *polrStore) Delete(ctx context.Context, name string, deleteValidation re
 		return nil, false, errors.NewBadRequest(fmt.Sprintf("invalid resource: %s", err.Error()))
 	}
 
+	klog.Infof("deleting policy reports name=%s namespace=%s", polr.Name, polr.Namespace)
 	if !isDryRun {
 		err = p.deletePolr(polr)
 		if err != nil {

--- a/pkg/app/opts/options.go
+++ b/pkg/app/opts/options.go
@@ -167,7 +167,7 @@ func (o Options) restConfig() (*rest.Config, error) {
 		return nil, fmt.Errorf("unable to construct lister client config: %v", err)
 	}
 
-	config.ContentType = "application/vnd.kubernetes.protobuf"
+	// config.ContentType = "application/vnd.kubernetes.protobuf"
 
 	err = rest.SetKubernetesDefaults(config)
 	if err != nil {

--- a/pkg/storage/db/ephr.go
+++ b/pkg/storage/db/ephr.go
@@ -39,8 +39,14 @@ func (p *ephrdb) List(ctx context.Context, namespace string) ([]reportsv1.Epheme
 	klog.Infof("listing all values for namespace:%s", namespace)
 	res := make([]reportsv1.EphemeralReport, 0)
 	var jsonb string
+	var rows *sql.Rows
+	var err error
 
-	rows, err := p.db.Query("SELECT report FROM ephemeralreports WHERE namespace = $1", namespace)
+	if len(namespace) == 0 {
+		rows, err = p.db.Query("SELECT report FROM ephemeralreports")
+	} else {
+		rows, err = p.db.Query("SELECT report FROM ephemeralreports WHERE namespace = $1", namespace)
+	}
 	if err != nil {
 		klog.ErrorS(err, "ephemeralreport list: ")
 		return nil, fmt.Errorf("ephemeralreport list %q: %v", namespace, err)

--- a/pkg/storage/db/new.go
+++ b/pkg/storage/db/new.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	maxRetries      = 10
-	backoffDuration = 30 * time.Second
+	maxRetries    = 10
+	sleepDuration = 15 * time.Second
 )
 
 func New(config *PostgresConfig) (api.Storage, error) {
@@ -24,16 +24,14 @@ func New(config *PostgresConfig) (api.Storage, error) {
 		return nil, err
 	}
 
-	sleepDuration := 30 * time.Second
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		time.Sleep(sleepDuration)
 		klog.Infof("pinging postgres db, attempt: %d", attempt)
 		err := db.PingContext(context.TODO())
 		if err == nil {
 			break
 		}
 		klog.Error("failed to ping db", err.Error())
-		sleepDuration = sleepDuration + backoffDuration
+		time.Sleep(sleepDuration)
 	}
 
 	err = db.Ping()

--- a/pkg/storage/db/new.go
+++ b/pkg/storage/db/new.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	maxRetries      = 10
-	backoffDuration = 15 * time.Second
+	backoffDuration = 30 * time.Second
 )
 
 func New(config *PostgresConfig) (api.Storage, error) {
@@ -24,7 +24,7 @@ func New(config *PostgresConfig) (api.Storage, error) {
 		return nil, err
 	}
 
-	sleepDuration := 0 * time.Second
+	sleepDuration := 30 * time.Second
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		time.Sleep(sleepDuration)
 		klog.Infof("pinging postgres db, attempt: %d", attempt)

--- a/pkg/storage/db/polr.go
+++ b/pkg/storage/db/polr.go
@@ -39,8 +39,15 @@ func (p *polrdb) List(ctx context.Context, namespace string) ([]v1alpha2.PolicyR
 	klog.Infof("listing all values for namespace:%s", namespace)
 	res := make([]v1alpha2.PolicyReport, 0)
 	var jsonb string
+	var rows *sql.Rows
+	var err error
 
-	rows, err := p.db.Query("SELECT report FROM policyreports WHERE namespace = $1", namespace)
+	if len(namespace) == 0 {
+		rows, err = p.db.Query("SELECT report FROM policyreports")
+	} else {
+		rows, err = p.db.Query("SELECT report FROM policyreports WHERE namespace = $1", namespace)
+	}
+
 	if err != nil {
 		klog.ErrorS(err, "policyreport list: ")
 		return nil, fmt.Errorf("policyreport list %q: %v", namespace, err)


### PR DESCRIPTION
Add support for fetching reports from all namespaces
```bash
❯ kubectl get polr -A
NAMESPACE   NAME                                   KIND   NAME                       PASS   FAIL   WARN   ERROR   SKIP   AGE
default     02e2ee18-8b4a-4196-99c3-d480468dfb92   Pod    signed-by-someone-else     0      1      0      0       0      10m28s
kyverno     test                                   Pod    test-pod                   1      0      0      0       0      8m56s
kyverno     aec3e0a6-cd38-436d-9aff-62c26b5bf04b   Pod    signed-by-someone-else     0      1      0      0       0      1m47s
default     08d9dcb5-dea7-4fad-bbc8-e6b973089459   Pod    unsigned                   0      1      0      0       0      10m28s
kyverno     2689aea5-f53d-4585-b238-1ac88d110b7b   Pod    unsigned                   0      1      0      0       0      1m46s
kyverno     1e241072-9d31-4fec-9139-c4f1f4e4631e   Pod    signed-by-someone-else-1   0      1      0      0       0      1m0s
kyverno     84cfd9ba-621c-442a-a01b-494f6ef6516e   Pod    unsigned-1                 0      1      0      0       0      1m0s
```