### PR TITLE
feat: add serializer to remove protobuf support

### DIFF
--- a/pkg/api/install.go
+++ b/pkg/api/install.go
@@ -51,6 +51,7 @@ func BuildPolicyReports(polr, cpolr rest.Storage) genericapiserver.APIGroupInfo 
 		"clusterpolicyreports": cpolr,
 	}
 	apiGroupInfo.VersionedResourcesStorageMap[v1alpha2.SchemeGroupVersion.Version] = policyReportsResources
+	apiGroupInfo.NegotiatedSerializer = DefaultSubsetNegotiatedSerializer(Codecs)
 
 	return apiGroupInfo
 }
@@ -63,6 +64,7 @@ func BuildEphemeralReports(ephr, cephr rest.Storage) genericapiserver.APIGroupIn
 		"clusterephemeralreports": cephr,
 	}
 	apiGroupInfo.VersionedResourcesStorageMap[reportsv1.SchemeGroupVersion.Version] = ephemeralReportsResources
+	apiGroupInfo.NegotiatedSerializer = DefaultSubsetNegotiatedSerializer(Codecs)
 
 	return apiGroupInfo
 }

--- a/pkg/api/serializer.go
+++ b/pkg/api/serializer.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+type subsetNegotiatedSerializer struct {
+	accepts []func(info runtime.SerializerInfo) bool
+	runtime.NegotiatedSerializer
+}
+
+func (s subsetNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	base := s.NegotiatedSerializer.SupportedMediaTypes()
+	var filtered []runtime.SerializerInfo
+	for _, info := range base {
+		for _, accept := range s.accepts {
+			if accept(info) {
+				filtered = append(filtered, info)
+				break
+			}
+		}
+	}
+	return filtered
+}
+
+func NoProtobuf(info runtime.SerializerInfo) bool {
+	return info.MediaType != runtime.ContentTypeProtobuf
+}
+
+func SubsetNegotiatedSerializer(codecs serializer.CodecFactory, accepts ...func(info runtime.SerializerInfo) bool) runtime.NegotiatedSerializer {
+	return subsetNegotiatedSerializer{accepts, codecs}
+}
+
+func DefaultSubsetNegotiatedSerializer(codecs serializer.CodecFactory) runtime.NegotiatedSerializer {
+	return SubsetNegotiatedSerializer(codecs, NoProtobuf)
+}

--- a/pkg/app/opts/options.go
+++ b/pkg/app/opts/options.go
@@ -167,7 +167,8 @@ func (o Options) restConfig() (*rest.Config, error) {
 		return nil, fmt.Errorf("unable to construct lister client config: %v", err)
 	}
 
-	// config.ContentType = "application/vnd.kubernetes.protobuf"
+	// config.ContentType = "application/json"
+	// config.AcceptContentTypes = "application/json,application/vnd.kubernetes.protobuf"
 
 	err = rest.SetKubernetesDefaults(config)
 	if err != nil {


### PR DESCRIPTION
This PR adds a serializer to remove protobuf support. Since some of our types do not support protobuf, namespace deletion fails because of it. This PR adds a custom serialiser that rejects protobuf media type.