### PR TITLE
fix: reports-server restart in default installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ REGISTER_GEN                       := $(TOOLS_DIR)/register-gen
 OPENAPI_GEN                        := $(TOOLS_DIR)/openapi-gen
 CODE_GEN_VERSION                   := v0.28.0
 KIND                               := $(TOOLS_DIR)/kind
-KIND_VERSION                       := v0.20.0
+KIND_VERSION                       := v0.23.0
 KO                                 := $(TOOLS_DIR)/ko
 KO_VERSION                         := v0.14.1
 HELM                               := $(TOOLS_DIR)/helm
@@ -192,7 +192,7 @@ verify-codegen: codegen ## Verify all generated code and docs are up to date
 # KIND #
 ########
 
-KIND_IMAGE     ?= kindest/node:v1.28.0
+KIND_IMAGE     ?= kindest/node:v1.30.0
 KIND_NAME      ?= kind
 
 .PHONY: kind-create

--- a/charts/reports-server/README.md
+++ b/charts/reports-server/README.md
@@ -42,8 +42,8 @@ helm install reports-server --namespace reports-server --create-namespace report
 | podAnnotations | object | `{}` | Pod annotations |
 | podSecurityContext | object | `{"fsGroup":2000}` | Pod security context |
 | securityContext | object | See [values.yaml](values.yaml) | Container security context |
-| livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/livez","port":"https","scheme":"HTTPS"},"periodSeconds":10}` | Liveness probe |
-| readinessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/readyz","port":"https","scheme":"HTTPS"},"initialDelaySeconds":20,"periodSeconds":10}` | Readiness probe |
+| livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/livez","port":"https","scheme":"HTTPS"},"initialDelaySeconds":90,"periodSeconds":10}` | Liveness probe |
+| readinessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/readyz","port":"https","scheme":"HTTPS"},"initialDelaySeconds":100,"periodSeconds":10}` | Readiness probe |
 | resources.limits | string | `nil` | Container resource limits |
 | resources.requests | string | `nil` | Container resource requests |
 | autoscaling.enabled | bool | `false` | Enable autoscaling |

--- a/charts/reports-server/values.yaml
+++ b/charts/reports-server/values.yaml
@@ -81,6 +81,7 @@ securityContext:
 # -- Liveness probe
 livenessProbe:
   failureThreshold: 3
+  initialDelaySeconds: 90
   periodSeconds: 10
   httpGet:
     path: /livez
@@ -89,7 +90,7 @@ livenessProbe:
 
 # -- Readiness probe
 readinessProbe:
-  initialDelaySeconds: 20
+  initialDelaySeconds: 100
   failureThreshold: 3
   periodSeconds: 10
   httpGet:

--- a/config/install-inmemory.yaml
+++ b/config/install-inmemory.yaml
@@ -198,6 +198,7 @@ spec:
               path: /livez
               port: https
               scheme: HTTPS
+            initialDelaySeconds: 90
             periodSeconds: 10
           readinessProbe:
             failureThreshold: 3
@@ -205,7 +206,7 @@ spec:
               path: /readyz
               port: https
               scheme: HTTPS
-            initialDelaySeconds: 20
+            initialDelaySeconds: 100
             periodSeconds: 10
           resources:
             limits: null

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -293,6 +293,7 @@ spec:
               path: /livez
               port: https
               scheme: HTTPS
+            initialDelaySeconds: 90
             periodSeconds: 10
           readinessProbe:
             failureThreshold: 3
@@ -300,7 +301,7 @@ spec:
               path: /readyz
               port: https
               scheme: HTTPS
-            initialDelaySeconds: 20
+            initialDelaySeconds: 100
             periodSeconds: 10
           resources:
             limits: null


### PR DESCRIPTION
In default installation, reports server creates postgres instance as well, which can take 30-90 seconds to start based on several conditions including network speed. Since reports server depends on this to start, it can cause liveness check to fail. This PR ups the numbers in values.yaml. It can be configured by users.