### PR TITLE
fix: annotate migrated reports

### DIFF
--- a/pkg/api/cephr.go
+++ b/pkg/api/cephr.go
@@ -136,7 +136,7 @@ func (c *cephrStore) Create(ctx context.Context, obj runtime.Object, createValid
 	}
 	if cephr.Name == "" {
 		if cephr.GenerateName == "" {
-			return nil, errors.NewConflict(utils.ClusterEphemeralReportsGR, cephr.Name, fmt.Errorf("name and generate name not provided"))
+			return nil, errors.NewAlreadyExists(utils.ClusterEphemeralReportsGR, cephr.Name)
 		}
 		cephr.Name = nameGenerator.GenerateName(cephr.GenerateName)
 	}

--- a/pkg/api/cpolr.go
+++ b/pkg/api/cpolr.go
@@ -136,7 +136,7 @@ func (c *cpolrStore) Create(ctx context.Context, obj runtime.Object, createValid
 	}
 	if cpolr.Name == "" {
 		if cpolr.GenerateName == "" {
-			return nil, errors.NewConflict(utils.ClusterPolicyReportsGR, cpolr.Name, fmt.Errorf("name and generate name not provided"))
+			return nil, errors.NewAlreadyExists(utils.ClusterPolicyReportsGR, cpolr.Name)
 		}
 		cpolr.Name = nameGenerator.GenerateName(cpolr.GenerateName)
 	}

--- a/pkg/api/ephr.go
+++ b/pkg/api/ephr.go
@@ -158,7 +158,7 @@ func (p *ephrStore) Create(ctx context.Context, obj runtime.Object, createValida
 	if !isDryRun {
 		r, err := p.createEphr(ephr)
 		if err != nil {
-			return nil, errors.NewBadRequest(fmt.Sprintf("cannot create ephemeral report: %s", err.Error()))
+			return nil, errors.NewAlreadyExists(utils.EphemeralReportsGR, ephr.Name)
 		}
 		if err := p.broadcaster.Action(watch.Added, r); err != nil {
 			klog.ErrorS(err, "failed to broadcast event")

--- a/pkg/api/polr.go
+++ b/pkg/api/polr.go
@@ -158,7 +158,7 @@ func (p *polrStore) Create(ctx context.Context, obj runtime.Object, createValida
 	if !isDryRun {
 		r, err := p.createPolr(polr)
 		if err != nil {
-			return nil, errors.NewBadRequest(fmt.Sprintf("cannot create policy report: %s", err.Error()))
+			return nil, errors.NewAlreadyExists(utils.PolicyReportsGR, polr.Name)
 		}
 		if err := p.broadcaster.Action(watch.Added, r); err != nil {
 			klog.ErrorS(err, "failed to broadcast event")

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -110,6 +110,14 @@ func (c Config) migration(store storage.Interface) error {
 		return nil
 	}
 	for _, c := range cpolrs.Items {
+		if c.Annotations != nil {
+			if _, ok := c.Annotations[api.ServedByReportsServerAnnotation]; ok {
+				continue
+			}
+		} else {
+			c.Annotations = make(map[string]string)
+		}
+		c.Annotations[api.ServedByReportsServerAnnotation] = api.ServedByReportsServerValue
 		err := store.ClusterPolicyReports().Create(context.TODO(), c)
 		if err != nil {
 			return err
@@ -138,7 +146,10 @@ func (c Config) migration(store storage.Interface) error {
 					if _, ok := cpolr.Annotations[api.ServedByReportsServerAnnotation]; ok {
 						return
 					}
+				} else {
+					cpolr.Annotations = make(map[string]string)
 				}
+				cpolr.Annotations[api.ServedByReportsServerAnnotation] = api.ServedByReportsServerValue
 				err := store.ClusterPolicyReports().Create(context.TODO(), *cpolr)
 				if err != nil {
 					klog.Error(err)
@@ -149,7 +160,10 @@ func (c Config) migration(store storage.Interface) error {
 					if _, ok := cpolr.Annotations[api.ServedByReportsServerAnnotation]; ok {
 						return
 					}
+				} else {
+					cpolr.Annotations = make(map[string]string)
 				}
+				cpolr.Annotations[api.ServedByReportsServerAnnotation] = api.ServedByReportsServerValue
 				err := store.ClusterPolicyReports().Update(context.TODO(), *cpolr)
 				if err != nil {
 					klog.Error(err)
@@ -160,7 +174,10 @@ func (c Config) migration(store storage.Interface) error {
 					if _, ok := cpolr.Annotations[api.ServedByReportsServerAnnotation]; ok {
 						return
 					}
+				} else {
+					cpolr.Annotations = make(map[string]string)
 				}
+				cpolr.Annotations[api.ServedByReportsServerAnnotation] = api.ServedByReportsServerValue
 				err := store.ClusterPolicyReports().Delete(context.TODO(), cpolr.Name)
 				if err != nil {
 					klog.Error(err)
@@ -174,6 +191,14 @@ func (c Config) migration(store storage.Interface) error {
 		return nil
 	}
 	for _, c := range polrs.Items {
+		if c.Annotations != nil {
+			if _, ok := c.Annotations[api.ServedByReportsServerAnnotation]; ok {
+				continue
+			}
+		} else {
+			c.Annotations = make(map[string]string)
+		}
+		c.Annotations[api.ServedByReportsServerAnnotation] = api.ServedByReportsServerValue
 		err := store.PolicyReports().Create(context.TODO(), c)
 		if err != nil {
 			return err
@@ -202,7 +227,10 @@ func (c Config) migration(store storage.Interface) error {
 					if _, ok := polr.Annotations[api.ServedByReportsServerAnnotation]; ok {
 						return
 					}
+				} else {
+					polr.Annotations = make(map[string]string)
 				}
+				polr.Annotations[api.ServedByReportsServerAnnotation] = api.ServedByReportsServerValue
 				err := store.PolicyReports().Create(context.TODO(), *polr)
 				if err != nil {
 					klog.Error(err)
@@ -213,7 +241,10 @@ func (c Config) migration(store storage.Interface) error {
 					if _, ok := polr.Annotations[api.ServedByReportsServerAnnotation]; ok {
 						return
 					}
+				} else {
+					polr.Annotations = make(map[string]string)
 				}
+				polr.Annotations[api.ServedByReportsServerAnnotation] = api.ServedByReportsServerValue
 				err := store.PolicyReports().Update(context.TODO(), *polr)
 				if err != nil {
 					klog.Error(err)
@@ -224,7 +255,10 @@ func (c Config) migration(store storage.Interface) error {
 					if _, ok := polr.Annotations[api.ServedByReportsServerAnnotation]; ok {
 						return
 					}
+				} else {
+					polr.Annotations = make(map[string]string)
 				}
+				polr.Annotations[api.ServedByReportsServerAnnotation] = api.ServedByReportsServerValue
 				err := store.PolicyReports().Delete(context.TODO(), polr.Name, polr.Namespace)
 				if err != nil {
 					klog.Error(err)
@@ -238,6 +272,14 @@ func (c Config) migration(store storage.Interface) error {
 		return nil
 	}
 	for _, c := range cephrs.Items {
+		if c.Annotations != nil {
+			if _, ok := c.Annotations[api.ServedByReportsServerAnnotation]; ok {
+				continue
+			}
+		} else {
+			c.Annotations = make(map[string]string)
+		}
+		c.Annotations[api.ServedByReportsServerAnnotation] = api.ServedByReportsServerValue
 		err := store.ClusterEphemeralReports().Create(context.TODO(), c)
 		if err != nil {
 			return err
@@ -265,7 +307,10 @@ func (c Config) migration(store storage.Interface) error {
 					if _, ok := cephr.Annotations[api.ServedByReportsServerAnnotation]; ok {
 						return
 					}
+				} else {
+					cephr.Annotations = make(map[string]string)
 				}
+				cephr.Annotations[api.ServedByReportsServerAnnotation] = api.ServedByReportsServerValue
 				err := store.ClusterEphemeralReports().Create(context.TODO(), *cephr)
 				if err != nil {
 					klog.Error(err)
@@ -276,7 +321,10 @@ func (c Config) migration(store storage.Interface) error {
 					if _, ok := cephr.Annotations[api.ServedByReportsServerAnnotation]; ok {
 						return
 					}
+				} else {
+					cephr.Annotations = make(map[string]string)
 				}
+				cephr.Annotations[api.ServedByReportsServerAnnotation] = api.ServedByReportsServerValue
 				err := store.ClusterEphemeralReports().Update(context.TODO(), *cephr)
 				if err != nil {
 					klog.Error(err)
@@ -287,7 +335,10 @@ func (c Config) migration(store storage.Interface) error {
 					if _, ok := cephr.Annotations[api.ServedByReportsServerAnnotation]; ok {
 						return
 					}
+				} else {
+					cephr.Annotations = make(map[string]string)
 				}
+				cephr.Annotations[api.ServedByReportsServerAnnotation] = api.ServedByReportsServerValue
 				err := store.ClusterEphemeralReports().Delete(context.TODO(), cephr.Name)
 				if err != nil {
 					klog.Error(err)
@@ -300,6 +351,14 @@ func (c Config) migration(store storage.Interface) error {
 		return nil
 	}
 	for _, c := range ephrs.Items {
+		if c.Annotations != nil {
+			if _, ok := c.Annotations[api.ServedByReportsServerAnnotation]; ok {
+				continue
+			}
+		} else {
+			c.Annotations = make(map[string]string)
+		}
+		c.Annotations[api.ServedByReportsServerAnnotation] = api.ServedByReportsServerValue
 		err := store.EphemeralReports().Create(context.TODO(), c)
 		if err != nil {
 			return err
@@ -327,7 +386,10 @@ func (c Config) migration(store storage.Interface) error {
 					if _, ok := ephr.Annotations[api.ServedByReportsServerAnnotation]; ok {
 						return
 					}
+				} else {
+					ephr.Annotations = make(map[string]string)
 				}
+				ephr.Annotations[api.ServedByReportsServerAnnotation] = api.ServedByReportsServerValue
 				err := store.EphemeralReports().Create(context.TODO(), *ephr)
 				if err != nil {
 					klog.Error(err)
@@ -338,7 +400,10 @@ func (c Config) migration(store storage.Interface) error {
 					if _, ok := ephr.Annotations[api.ServedByReportsServerAnnotation]; ok {
 						return
 					}
+				} else {
+					ephr.Annotations = make(map[string]string)
 				}
+				ephr.Annotations[api.ServedByReportsServerAnnotation] = api.ServedByReportsServerValue
 				err := store.EphemeralReports().Update(context.TODO(), *ephr)
 				if err != nil {
 					klog.Error(err)
@@ -349,7 +414,10 @@ func (c Config) migration(store storage.Interface) error {
 					if _, ok := ephr.Annotations[api.ServedByReportsServerAnnotation]; ok {
 						return
 					}
+				} else {
+					ephr.Annotations = make(map[string]string)
 				}
+				ephr.Annotations[api.ServedByReportsServerAnnotation] = api.ServedByReportsServerValue
 				err := store.EphemeralReports().Delete(context.TODO(), ephr.Name, ephr.Namespace)
 				if err != nil {
 					klog.Error(err)


### PR DESCRIPTION
Closes: #174 

This PR adds annotation to reports that are already added in reports-server to avoid the case where reports-server fetches already existing reports and tries to re-add them to the db