### PR TITLE
Add option to use individual secrets for db host, port, name, user and password

### DIFF
--- a/charts/reports-server/README.md
+++ b/charts/reports-server/README.md
@@ -22,79 +22,84 @@ helm install reports-server --namespace reports-server --create-namespace report
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| postgresql.enabled | bool | `true` | Deploy postgresql dependency chart |
-| postgresql.auth.postgresPassword | string | `"reports"` |  |
-| postgresql.auth.database | string | `"reportsdb"` |  |
-| nameOverride | string | `""` | Name override |
+| affinity | object | `{}` | Affinity |
+| apiServicesManagement.enabled | bool | `true` | Create a helm hooks to install and delete api services |
+| apiServicesManagement.image.pullPolicy | string | `nil` | Image pull policy Defaults to image.pullPolicy if omitted |
+| apiServicesManagement.image.registry | string | `"docker.io"` | Image registry |
+| apiServicesManagement.image.repository | string | `"bitnami/kubectl"` | Image repository |
+| apiServicesManagement.image.tag | string | `"1.30.2"` | Image tag Defaults to `latest` if omitted |
+| apiServicesManagement.imagePullSecrets | list | `[]` | Image pull secrets |
+| apiServicesManagement.installApiServices | object | `{"enabled":false,"installEphemeralReportsService":true}` | Install api services in manifest |
+| apiServicesManagement.installApiServices.enabled | bool | `false` | Store reports in reports-server |
+| apiServicesManagement.installApiServices.installEphemeralReportsService | bool | `true` | Store ephemeral reports in reports-server |
+| apiServicesManagement.nodeAffinity | object | `{}` | Node affinity constraints. |
+| apiServicesManagement.nodeSelector | object | `{}` | Node labels for pod assignment |
+| apiServicesManagement.podAffinity | object | `{}` | Pod affinity constraints. |
+| apiServicesManagement.podAnnotations | object | `{}` | Pod annotations. |
+| apiServicesManagement.podAntiAffinity | object | `{}` | Pod anti affinity constraints. |
+| apiServicesManagement.podLabels | object | `{}` | Pod labels. |
+| apiServicesManagement.podSecurityContext | object | `{}` | Security context for the pod |
+| apiServicesManagement.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the hook containers |
+| apiServicesManagement.tolerations | list | `[]` | List of node taints to tolerate |
+| autoscaling.enabled | bool | `false` | Enable autoscaling |
+| autoscaling.maxReplicas | int | `100` | Max number of replicas |
+| autoscaling.minReplicas | int | `1` | Min number of replicas |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilisation |
+| autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target Memory utilisation |
+| config.db.dbNameSecretKeyName | string | `"dbname"` | The database name will be read from this `key` in the specified Secret, when `db.secretName` or `db.dbNameSecretName` is set. |
+| config.db.dbNameSecretName | string | `""` | If set, database name will be read from this Secret. Overrides `db.name` and `db.secretName`. |
+| config.db.host | string | `""` | Database host |
+| config.db.hostSecretKeyName | string | `"host"` | The database host will be read from this `key` in the specified Secret, when `db.secretName` or `db.hostSecretName` is set. |
+| config.db.hostSecretName | string | `""` | If set, database host will be read from this Secret. Overrides `db.host` and `db.secretName`. |
+| config.db.name | string | `"reportsdb"` | Database name |
+| config.db.password | string | `"reports"` | Database password |
+| config.db.passwordSecretKeyName | string | `"password"` | The database password will be read from this `key` in the specified Secret, when `db.secretName` is set. |
+| config.db.passwordSecretName | string | `""` | If set, database password will be read from this Secret. Overrides `db.password` and `db.secretName`. |
+| config.db.port | int | `5432` | Database port |
+| config.db.portSecretKeyName | string | `"port"` | The database port will be read from this `key` in the specified Secret, when `db.secretName` or `db.portSecretName` is set. |
+| config.db.portSecretName | string | `""` | If set, database port will be read from this Secret. Overrides `db.port` and `db.secretName`. |
+| config.db.secretName | string | `""` | If set, database connection information will be read from the Secret with this name. Overrides `db.host`, `db.name`, `db.user`, and `db.password`. |
+| config.db.sslcert | string | `""` | Database SSL cert |
+| config.db.sslkey | string | `""` | Database SSL key |
+| config.db.sslmode | string | `"disable"` | Database SSL |
+| config.db.sslrootcert | string | `""` | Database SSL root cert |
+| config.db.user | string | `"postgres"` | Database user |
+| config.db.userSecretKeyName | string | `"username"` | The database username will be read from this `key` in the specified Secret, when `db.secretName` or `db.userSecretName` is set. |
+| config.db.userSecretName | string | `""` | If set, database user will be read from this Secret. Overrides `db.user` and `db.secretName`. |
+| config.debug | bool | `false` | Enable debug (to use inmemorydatabase) |
 | fullnameOverride | string | `""` | Full name override |
-| replicaCount | int | `1` | Number of pod replicas |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.registry | string | `"ghcr.io"` | Image registry |
 | image.repository | string | `"kyverno/reports-server"` | Image repository |
-| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.tag | string | `nil` | Image tag (will default to app version if not set) |
 | imagePullSecrets | list | `[]` | Image pull secrets |
-| priorityClassName | string | `"system-cluster-critical"` | Priority class name |
-| serviceAccount.create | bool | `true` | Create service account |
-| serviceAccount.annotations | object | `{}` | Service account annotations |
-| serviceAccount.name | string | `""` | Service account name (required if `serviceAccount.create` is `false`) |
-| podAnnotations | object | `{}` | Pod annotations |
-| podSecurityContext | object | `{"fsGroup":2000}` | Pod security context |
-| securityContext | object | See [values.yaml](values.yaml) | Container security context |
 | livenessProbe | object | `{"failureThreshold":10,"httpGet":{"path":"/livez","port":"https","scheme":"HTTPS"},"initialDelaySeconds":20,"periodSeconds":10}` | Liveness probe |
-| readinessProbe | object | `{"failureThreshold":10,"httpGet":{"path":"/readyz","port":"https","scheme":"HTTPS"},"initialDelaySeconds":30,"periodSeconds":10}` | Readiness probe |
 | metrics.enabled | bool | `true` | Enable prometheus metrics |
-| metrics.serviceMonitor.enabled | bool | `false` | Enable service monitor for scraping prometheus metrics |
 | metrics.serviceMonitor.additionalLabels | object | `{}` | Service monitor additional labels |
+| metrics.serviceMonitor.enabled | bool | `false` | Enable service monitor for scraping prometheus metrics |
 | metrics.serviceMonitor.interval | string | `""` | Service monitor scrape interval |
 | metrics.serviceMonitor.metricRelabelings | list | `[]` | Service monitor metric relabelings |
 | metrics.serviceMonitor.relabelings | list | `[]` | Service monitor relabelings |
 | metrics.serviceMonitor.scrapeTimeout | string | `""` | Service monitor scrape timeout |
+| nameOverride | string | `""` | Name override |
+| nodeSelector | object | `{}` | Node selector |
+| podAnnotations | object | `{}` | Pod annotations |
+| podSecurityContext | object | `{"fsGroup":2000}` | Pod security context |
+| postgresql.auth.database | string | `"reportsdb"` |  |
+| postgresql.auth.postgresPassword | string | `"reports"` |  |
+| postgresql.enabled | bool | `true` | Deploy postgresql dependency chart |
+| priorityClassName | string | `"system-cluster-critical"` | Priority class name |
+| readinessProbe | object | `{"failureThreshold":10,"httpGet":{"path":"/readyz","port":"https","scheme":"HTTPS"},"initialDelaySeconds":30,"periodSeconds":10}` | Readiness probe |
+| replicaCount | int | `1` | Number of pod replicas |
 | resources.limits | string | `nil` | Container resource limits |
 | resources.requests | string | `nil` | Container resource requests |
-| autoscaling.enabled | bool | `false` | Enable autoscaling |
-| autoscaling.minReplicas | int | `1` | Min number of replicas |
-| autoscaling.maxReplicas | int | `100` | Max number of replicas |
-| autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilisation |
-| autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target Memory utilisation |
-| nodeSelector | object | `{}` | Node selector |
-| tolerations | list | `[]` | Tolerations |
-| affinity | object | `{}` | Affinity |
-| service.type | string | `"ClusterIP"` | Service type |
+| securityContext | object | See [values.yaml](values.yaml) | Container security context |
 | service.port | int | `443` | Service port |
-| config.debug | bool | `false` | Enable debug (to use inmemorydatabase) |
-| config.db.secretName | string | `""` | If set, database connection information will be read from the Secret with this name. Overrides `db.host`, `db.name`, `db.user`, and `db.password`. |
-| config.db.host | string | `""` | Database host |
-| config.db.hostSecretKeyName | string | `"host"` | The database host will be read from this `key` in the specified Secret, when `db.secretName` is set. |
-| config.db.port | int | `5432` | Database port |
-| config.db.portSecretKeyName | string | `"port"` | The database port will be read from this `key` in the specified Secret, when `db.secretName` is set. |
-| config.db.name | string | `"reportsdb"` | Database name |
-| config.db.dbNameSecretKeyName | string | `"dbname"` | The database name will be read from this `key` in the specified Secret, when `db.secretName` is set. |
-| config.db.user | string | `"postgres"` | Database user |
-| config.db.userSecretKeyName | string | `"username"` | The database username will be read from this `key` in the specified Secret, when `db.secretName` is set. |
-| config.db.password | string | `"reports"` | Database password |
-| config.db.passwordSecretKeyName | string | `"password"` | The database password will be read from this `key` in the specified Secret, when `db.secretName` is set. |
-| config.db.sslmode | string | `"disable"` | Database SSL |
-| config.db.sslrootcert | string | `""` | Database SSL root cert |
-| config.db.sslkey | string | `""` | Database SSL key |
-| config.db.sslcert | string | `""` | Database SSL cert |
-| apiServicesManagement.enabled | bool | `true` | Create a helm hooks to install and delete api services |
-| apiServicesManagement.installApiServices | object | `{"enabled":false,"installEphemeralReportsService":true}` | Install api services in manifest |
-| apiServicesManagement.installApiServices.enabled | bool | `false` | Store reports in reports-server |
-| apiServicesManagement.installApiServices.installEphemeralReportsService | bool | `true` | Store ephemeral reports in reports-server |
-| apiServicesManagement.image.registry | string | `"docker.io"` | Image registry |
-| apiServicesManagement.image.repository | string | `"bitnami/kubectl"` | Image repository |
-| apiServicesManagement.image.tag | string | `"1.30.2"` | Image tag Defaults to `latest` if omitted |
-| apiServicesManagement.image.pullPolicy | string | `nil` | Image pull policy Defaults to image.pullPolicy if omitted |
-| apiServicesManagement.imagePullSecrets | list | `[]` | Image pull secrets |
-| apiServicesManagement.podSecurityContext | object | `{}` | Security context for the pod |
-| apiServicesManagement.nodeSelector | object | `{}` | Node labels for pod assignment |
-| apiServicesManagement.tolerations | list | `[]` | List of node taints to tolerate |
-| apiServicesManagement.podAntiAffinity | object | `{}` | Pod anti affinity constraints. |
-| apiServicesManagement.podAffinity | object | `{}` | Pod affinity constraints. |
-| apiServicesManagement.podLabels | object | `{}` | Pod labels. |
-| apiServicesManagement.podAnnotations | object | `{}` | Pod annotations. |
-| apiServicesManagement.nodeAffinity | object | `{}` | Node affinity constraints. |
-| apiServicesManagement.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the hook containers |
+| service.type | string | `"ClusterIP"` | Service type |
+| serviceAccount.annotations | object | `{}` | Service account annotations |
+| serviceAccount.create | bool | `true` | Create service account |
+| serviceAccount.name | string | `""` | Service account name (required if `serviceAccount.create` is `false`) |
+| tolerations | list | `[]` | Tolerations |
 
 ## Source Code
 
@@ -115,4 +120,4 @@ Kubernetes: `>=1.16.0-0`
 | Nirmata | <cncf-kyverno-maintainers@lists.cncf.io> | <https://kyverno.io/> |
 
 ----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/reports-server/templates/_helpers.tpl
+++ b/charts/reports-server/templates/_helpers.tpl
@@ -65,7 +65,7 @@ Create the name of the service account to use
 Database config is injected into the environment, if a secret ref is set. Otherwise, Helm values are used directly.
 */}}
 {{- define "reports-server.dbHost" -}}
-{{- if .Values.config.db.secretName }}
+{{- if or (.Values.config.db.secretName) (.Values.config.db.hostSecretName) }}
 {{- printf "%s" "$(DB_HOST)" }}
 {{- else }}
 {{- default (printf "%s-postgresql.%s" $.Release.Name $.Release.Namespace ) .Values.config.db.host }}
@@ -73,7 +73,7 @@ Database config is injected into the environment, if a secret ref is set. Otherw
 {{- end }}
 
 {{- define "reports-server.dbPort" -}}
-{{- if .Values.config.db.secretName }}
+{{- if or (.Values.config.db.secretName) (.Values.config.db.portSecretName) }}
 {{- printf "%s" "$(DB_PORT)" }}
 {{- else }}
 {{- .Values.config.db.port }}
@@ -81,7 +81,7 @@ Database config is injected into the environment, if a secret ref is set. Otherw
 {{- end }}
 
 {{- define "reports-server.dbName" -}}
-{{- if .Values.config.db.secretName }}
+{{- if or (.Values.config.db.secretName) (.Values.config.db.dbNameSecretName) }}
 {{- printf "%s" "$(DB_DATABASE)" }}
 {{- else }}
 {{- .Values.config.db.name }}
@@ -89,7 +89,7 @@ Database config is injected into the environment, if a secret ref is set. Otherw
 {{- end }}
 
 {{- define "reports-server.dbUser" -}}
-{{- if .Values.config.db.secretName }}
+{{- if or (.Values.config.db.secretName) (.Values.config.db.userSecretName) }}
 {{- printf "%s" "$(DB_USER)" }}
 {{- else }}
 {{- .Values.config.db.user }}
@@ -97,7 +97,7 @@ Database config is injected into the environment, if a secret ref is set. Otherw
 {{- end }}
 
 {{- define "reports-server.dbPassword" -}}
-{{- if .Values.config.db.secretName }}
+{{- if or (.Values.config.db.secretName) (.Values.config.db.passwordSecretName) }}
 {{- printf "%s" "$(DB_PASSWORD)" }}
 {{- else }}
 {{- .Values.config.db.password }}

--- a/charts/reports-server/templates/deployment.yaml
+++ b/charts/reports-server/templates/deployment.yaml
@@ -55,33 +55,43 @@ spec:
             {{- if .Values.metrics.enabled }}
             - --authorization-always-allow-paths=/metrics
             {{- end }}
-          {{- if .Values.config.db.secretName }}
+          {{- if or (.Values.config.db.secretName) (.Values.config.db.hostSecretName) (.Values.config.db.portSecretName) (.Values.config.db.dbNameSecretName) (.Values.config.db.userSecretName) (.Values.config.db.passwordSecretName) }}
           env:
+            {{- if or (.Values.config.db.secretName) (.Values.config.db.hostSecretName) }}
             - name: DB_HOST
               valueFrom:
                 secretKeyRef:
                   key: {{ .Values.config.db.hostSecretKeyName }}
-                  name: {{ .Values.config.db.secretName }}
+                  name: {{ .Values.config.db.hostSecretName | default .Values.config.db.secretName }}
+            {{- end}}
+            {{- if or (.Values.config.db.secretName) (.Values.config.db.portSecretName) }}
             - name: DB_PORT
               valueFrom:
                 secretKeyRef:
                   key: {{ .Values.config.db.portSecretKeyName }}
-                  name: {{ .Values.config.db.secretName }}
+                  name: {{ .Values.config.db.portSecretName | default .Values.config.db.secretName }}
+            {{- end}}
+            {{- if or (.Values.config.db.secretName) (.Values.config.db.dbNameSecretName) }}
             - name: DB_DATABASE
               valueFrom:
                 secretKeyRef:
                   key: {{ .Values.config.db.dbNameSecretKeyName }}
-                  name: {{ .Values.config.db.secretName }}
+                  name: {{ .Values.config.db.dbNameSecretName | default .Values.config.db.secretName }}
+            {{- end}}
+            {{- if or (.Values.config.db.secretName) (.Values.config.db.userSecretName) }}
             - name: DB_USER
               valueFrom:
                 secretKeyRef:
                   key: {{ .Values.config.db.userSecretKeyName }}
-                  name: {{ .Values.config.db.secretName }}
+                  name: {{ .Values.config.db.userSecretName | default .Values.config.db.secretName }}
+            {{- end}}
+            {{- if or (.Values.config.db.secretName) (.Values.config.db.passwordSecretName) }}
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   key: {{ .Values.config.db.passwordSecretKeyName }}
-                  name: {{ .Values.config.db.secretName }}
+                  name: {{ .Values.config.db.passwordSecretName | default .Values.config.db.secretName }}
+            {{- end}}
           {{- end}}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/reports-server/values.yaml
+++ b/charts/reports-server/values.yaml
@@ -171,28 +171,36 @@ config:
 
     # -- Database host
     host: ""
-    # -- The database host will be read from this `key` in the specified Secret, when `db.secretName` is set.
+    # -- If set, database host will be read from this Secret. Overrides `db.host` and `db.secretName`.
+    hostSecretName: ""
+    # -- The database host will be read from this `key` in the specified Secret, when `db.secretName` or `db.hostSecretName` is set.
     hostSecretKeyName: "host"
 
     # -- Database port
     port: 5432
-    # -- The database port will be read from this `key` in the specified Secret, when `db.secretName` is set.
+    # -- If set, database port will be read from this Secret. Overrides `db.port` and `db.secretName`.
+    portSecretName: ""
+    # -- The database port will be read from this `key` in the specified Secret, when `db.secretName` or `db.portSecretName` is set.
     portSecretKeyName: "port"
 
     # -- Database name
     name: reportsdb
-    # -- The database name will be read from this `key` in the specified Secret, when `db.secretName` is set.
+    # -- If set, database name will be read from this Secret. Overrides `db.name` and `db.secretName`.
+    dbNameSecretName: ""
+    # -- The database name will be read from this `key` in the specified Secret, when `db.secretName` or `db.dbNameSecretName` is set.
     dbNameSecretKeyName: "dbname"
 
     # -- Database user
     user: postgres
-
-    # -- The database username will be read from this `key` in the specified Secret, when `db.secretName` is set.
+    # -- If set, database user will be read from this Secret. Overrides `db.user` and `db.secretName`.
+    userSecretName: ""
+    # -- The database username will be read from this `key` in the specified Secret, when `db.secretName` or `db.userSecretName` is set.
     userSecretKeyName: "username"
 
     # -- Database password
     password: reports
-
+    # -- If set, database password will be read from this Secret. Overrides `db.password` and `db.secretName`.
+    passwordSecretName: ""
     # -- The database password will be read from this `key` in the specified Secret, when `db.secretName` is set.
     passwordSecretKeyName: "password"
 


### PR DESCRIPTION
Retains backwards compatibility with existing `.Values.config.db.secretName`, with the new values overriding that if set.

I'm specifically looking for this so I can e.g. only use a Secret for the user and password, with the others being set directly in values.