### PR TITLE
Fix outdated/removed python version

### DIFF
--- a/.github/workflows/ct-lint.yaml
+++ b/.github/workflows/ct-lint.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: 3.7
+          python-version: 3.12
       - name: Set up chart-testing
         uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1
       - name: Run chart-testing (lint)

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
       - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: 3.7
+          python-version: 3.12
       - name: Set up chart-testing
         uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1
       - name: Run chart-testing (lint)


### PR DESCRIPTION
Pipeline is running on ubuntu-latest, and has changed to ubuntu 24.04, which only has python 3.8.12 and later
Python 3.7 has been EoL for quite some time, and explicitly defined in the pipeline
Switching to 3.12 which is the currently minimum version that is still under bugfix support ,ref: https://devguide.python.org/versions/

Fixes [#244 ](https://github.com/kyverno/reports-server/issues/244)