### PR TITLE
Allow using secret injection on env vars, e.g. using vault-env

### DIFF
--- a/charts/reports-server/templates/_helpers.tpl
+++ b/charts/reports-server/templates/_helpers.tpl
@@ -62,45 +62,60 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Database config is injected into the environment, if a secret ref is set. Otherwise, Helm values are used directly.
+Database config is injected into the environment and passed to the command line from there, if secretName is set, the values will be read from there .
 */}}
 {{- define "reports-server.dbHost" -}}
-{{- if .Values.config.db.secretName }}
-{{- printf "%s" "$(DB_HOST)" }}
-{{- else }}
-{{- default (printf "%s-postgresql.%s" $.Release.Name $.Release.Namespace ) .Values.config.db.host }}
+{{- if .Values.config.db.secretName -}}
+valueFrom:
+  secretKeyRef:
+    key: {{ .Values.config.db.hostSecretKeyName }}
+    name: {{ .Values.config.db.secretName }}
+{{- else -}}
+value: {{ default (printf "%s-postgresql.%s" $.Release.Name $.Release.Namespace ) .Values.config.db.host | quote }}
 {{- end }}
 {{- end }}
 
 {{- define "reports-server.dbPort" -}}
-{{- if .Values.config.db.secretName }}
-{{- printf "%s" "$(DB_PORT)" }}
-{{- else }}
-{{- .Values.config.db.port }}
+{{- if .Values.config.db.secretName -}}
+valueFrom:
+  secretKeyRef:
+    key: {{ .Values.config.db.portSecretKeyName }}
+    name: {{ .Values.config.db.secretName }}
+{{- else -}}
+value: {{ .Values.config.db.port | quote }}
 {{- end }}
 {{- end }}
 
 {{- define "reports-server.dbName" -}}
-{{- if .Values.config.db.secretName }}
-{{- printf "%s" "$(DB_DATABASE)" }}
-{{- else }}
-{{- .Values.config.db.name }}
+{{- if .Values.config.db.secretName -}}
+valueFrom:
+  secretKeyRef:
+    key: {{ .Values.config.db.dbNameSecretKeyName }}
+    name: {{ .Values.config.db.secretName }}
+{{- else -}}
+value: {{ .Values.config.db.name | quote }}
 {{- end }}
 {{- end }}
 
 {{- define "reports-server.dbUser" -}}
-{{- if .Values.config.db.secretName }}
-{{- printf "%s" "$(DB_USER)" }}
-{{- else }}
-{{- .Values.config.db.user }}
+{{- if .Values.config.db.secretName -}}
+valueFrom:
+  secretKeyRef:
+    key: {{ .Values.config.db.userSecretKeyName }}
+    name: {{ .Values.config.db.secretName }}
+{{- else -}}
+value: {{ .Values.config.db.user | quote }}
 {{- end }}
 {{- end }}
 
 {{- define "reports-server.dbPassword" -}}
-{{- if .Values.config.db.secretName }}
-{{- printf "%s" "$(DB_PASSWORD)" }}
-{{- else }}
-{{- .Values.config.db.password }}
+{{- if .Values.config.db.secretName -}}
+valueFrom:
+  secretKeyRef:
+    key: {{ .Values.config.db.passwordSecretKeyName }}
+    name: {{ .Values.config.db.secretName }}
+{{- else -}}
+value: {{ .Values.config.db.password | quote }}
 {{- end }}
 {{- end }}
 

--- a/charts/reports-server/templates/deployment.yaml
+++ b/charts/reports-server/templates/deployment.yaml
@@ -45,11 +45,11 @@ spec:
             {{- end }}
             - --etcdEndpoints=https://etcd-0.etcd.{{ $.Release.Namespace }}:2379,https://etcd-1.etcd.{{ $.Release.Namespace }}:2379,https://etcd-2.etcd.{{ $.Release.Namespace }}:2379
             {{- else }}
-            - --dbhost=${DB_HOST}
-            - --dbport=${DB_PORT}
-            - --dbuser=${DB_USER}
-            - --dbpassword=${DB_PASSWORD}
-            - --dbname=${DB_DATABASE}
+            - --dbhost=$(DB_HOST)
+            - --dbport=$(DB_PORT)
+            - --dbuser=$(DB_USER)
+            - --dbpassword=$(DB_PASSWORD)
+            - --dbname=$(DB_DATABASE)
             - --dbsslmode={{ .Values.config.db.sslmode }}
             - --dbsslrootcert={{ .Values.config.db.sslrootcert }}
             - --dbsslkey={{ .Values.config.db.sslkey }}

--- a/charts/reports-server/templates/deployment.yaml
+++ b/charts/reports-server/templates/deployment.yaml
@@ -45,11 +45,11 @@ spec:
             {{- end }}
             - --etcdEndpoints=https://etcd-0.etcd.{{ $.Release.Namespace }}:2379,https://etcd-1.etcd.{{ $.Release.Namespace }}:2379,https://etcd-2.etcd.{{ $.Release.Namespace }}:2379
             {{- else }}
-            - --dbhost={{ include "reports-server.dbHost" . }}
-            - --dbport={{ include "reports-server.dbPort" . }}
-            - --dbuser={{ include "reports-server.dbUser" . }}
-            - --dbpassword={{ include "reports-server.dbPassword" . }}
-            - --dbname={{ include "reports-server.dbName" . }}
+            - --dbhost=${DB_HOST}
+            - --dbport=${DB_PORT}
+            - --dbuser=${DB_USER}
+            - --dbpassword=${DB_PASSWORD}
+            - --dbname=${DB_DATABASE}
             - --dbsslmode={{ .Values.config.db.sslmode }}
             - --dbsslrootcert={{ .Values.config.db.sslrootcert }}
             - --dbsslkey={{ .Values.config.db.sslkey }}
@@ -66,36 +66,19 @@ spec:
                 resourceFieldRef:
                   resource: limits.memory
                   divisor: '1'
+            - name: DB_HOST
+              {{- include "reports-server.dbHost" . | nindent 14 }}
+            - name: DB_PORT
+              {{- include "reports-server.dbPort" . | nindent 14 }}
+            - name: DB_DATABASE
+              {{- include "reports-server.dbName" . | nindent 14 }}
+            - name: DB_USER
+              {{- include "reports-server.dbUser" . | nindent 14 }}
+            - name: DB_PASSWORD
+              {{- include "reports-server.dbPassword" . | nindent 14 }}
           {{- with $env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.config.db.secretName }}
-            - name: DB_HOST
-              valueFrom:
-                secretKeyRef:
-                  key: {{ .Values.config.db.hostSecretKeyName }}
-                  name: {{ .Values.config.db.secretName }}
-            - name: DB_PORT
-              valueFrom:
-                secretKeyRef:
-                  key: {{ .Values.config.db.portSecretKeyName }}
-                  name: {{ .Values.config.db.secretName }}
-            - name: DB_DATABASE
-              valueFrom:
-                secretKeyRef:
-                  key: {{ .Values.config.db.dbNameSecretKeyName }}
-                  name: {{ .Values.config.db.secretName }}
-            - name: DB_USER
-              valueFrom:
-                secretKeyRef:
-                  key: {{ .Values.config.db.userSecretKeyName }}
-                  name: {{ .Values.config.db.secretName }}
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  key: {{ .Values.config.db.passwordSecretKeyName }}
-                  name: {{ .Values.config.db.secretName }}
-          {{- end}}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           volumeMounts:

--- a/config/install-etcd.yaml
+++ b/config/install-etcd.yaml
@@ -276,6 +276,16 @@ spec:
                 resourceFieldRef:
                   resource: limits.memory
                   divisor: '1'
+            - name: DB_HOST
+              value: "reports-server-postgresql.reports-server"
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_DATABASE
+              value: "reportsdb"
+            - name: DB_USER
+              value: "postgres"
+            - name: DB_PASSWORD
+              value: "reports"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -326,11 +326,11 @@ spec:
       containers:
         - name: reports-server
           args:
-            - --dbhost=reports-server-postgresql.reports-server
-            - --dbport=5432
-            - --dbuser=postgres
-            - --dbpassword=reports
-            - --dbname=reportsdb
+            - --dbhost=${DB_HOST}
+            - --dbport=${DB_PORT}
+            - --dbuser=${DB_USER}
+            - --dbpassword=${DB_PASSWORD}
+            - --dbname=${DB_DATABASE}
             - --dbsslmode=disable
             - --dbsslrootcert=
             - --dbsslkey=
@@ -344,6 +344,16 @@ spec:
                 resourceFieldRef:
                   resource: limits.memory
                   divisor: '1'
+            - name: DB_HOST
+              value: "reports-server-postgresql.reports-server"
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_DATABASE
+              value: "reportsdb"
+            - name: DB_USER
+              value: "postgres"
+            - name: DB_PASSWORD
+              value: "reports"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -326,11 +326,11 @@ spec:
       containers:
         - name: reports-server
           args:
-            - --dbhost=${DB_HOST}
-            - --dbport=${DB_PORT}
-            - --dbuser=${DB_USER}
-            - --dbpassword=${DB_PASSWORD}
-            - --dbname=${DB_DATABASE}
+            - --dbhost=$(DB_HOST)
+            - --dbport=$(DB_PORT)
+            - --dbuser=$(DB_USER)
+            - --dbpassword=$(DB_PASSWORD)
+            - --dbname=$(DB_DATABASE)
             - --dbsslmode=disable
             - --dbsslrootcert=
             - --dbsslkey=


### PR DESCRIPTION
This change doesn't impact existing configurations, but it now allows to pass arbitrary values for database credentials as env variables.
This allows for example to use secret injection such as provided by vault-env