### PR TITLE
Bump down default readinessprobe delays

### DIFF
--- a/charts/reports-server/README.md
+++ b/charts/reports-server/README.md
@@ -43,7 +43,7 @@ helm install reports-server --namespace reports-server --create-namespace report
 | podEnv | object | `{}` | Provide additional environment variables to the pods. Map with the same format as kubernetes deployment spec's env. |
 | securityContext | object | See [values.yaml](values.yaml) | Container security context |
 | livenessProbe | object | `{"failureThreshold":10,"httpGet":{"path":"/livez","port":"https","scheme":"HTTPS"},"initialDelaySeconds":20,"periodSeconds":10}` | Liveness probe |
-| readinessProbe | object | `{"failureThreshold":10,"httpGet":{"path":"/readyz","port":"https","scheme":"HTTPS"},"initialDelaySeconds":30,"periodSeconds":10}` | Readiness probe |
+| readinessProbe | object | `{"failureThreshold":10,"httpGet":{"path":"/readyz","port":"https","scheme":"HTTPS"},"initialDelaySeconds":1,"periodSeconds":5}` | Readiness probe |
 | metrics.enabled | bool | `true` | Enable prometheus metrics |
 | metrics.serviceMonitor.enabled | bool | `false` | Enable service monitor for scraping prometheus metrics |
 | metrics.serviceMonitor.additionalLabels | object | `{}` | Service monitor additional labels |

--- a/charts/reports-server/values.yaml
+++ b/charts/reports-server/values.yaml
@@ -88,9 +88,9 @@ livenessProbe:
 
 # -- Readiness probe
 readinessProbe:
-  initialDelaySeconds: 30
+  initialDelaySeconds: 1
   failureThreshold: 10
-  periodSeconds: 10
+  periodSeconds: 5
   httpGet:
     path: /readyz
     port: https

--- a/config/install-etcd.yaml
+++ b/config/install-etcd.yaml
@@ -327,8 +327,8 @@ spec:
               path: /readyz
               port: https
               scheme: HTTPS
-            initialDelaySeconds: 30
-            periodSeconds: 10
+            initialDelaySeconds: 1
+            periodSeconds: 5
           resources:
             limits: null
             requests: null

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -395,8 +395,8 @@ spec:
               path: /readyz
               port: https
               scheme: HTTPS
-            initialDelaySeconds: 30
-            periodSeconds: 10
+            initialDelaySeconds: 1
+            periodSeconds: 5
           resources:
             limits: null
             requests: null


### PR DESCRIPTION
This change avoids unnecessary delays during pod rollouts, since the probes already correctly handle when to report ready.