### PR TITLE
Fix variable injection, add common labels to all resources, fix requi…

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,12 +5,12 @@ linters:
     - bidichk
     - bodyclose
     - containedctx
+    - copyloopvar
     - decorder
     - dogsled
     - durationcheck
     - errcheck
     - errname
-    - exportloopref
     - gci
     # - gochecknoinits
     - gofmt
@@ -30,20 +30,23 @@ linters:
     - nosprintfhostport
     # - paralleltest
     - staticcheck
-    - tenv
     - thelper
     - tparallel
     - typecheck
     - unconvert
     - unused
+    - usetesting
     - wastedassign
     - whitespace
 
 run:
   timeout: 15m
-  skip-files:
+
+issues:
+  exclude-files:
     - ".+\\.generated.go"
 
 output:
-  format: colored-line-number
+  formats:
+    - format: colored-line-number
   sort-results: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.22.2 as build
 WORKDIR /
 COPY . ./
 
-RUN GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-w -s" -o reports-server ./main.go
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-w -s" -o reports-server ./main.go
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.22.2 as build
 WORKDIR /
 COPY . ./
 
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-w -s" -o reports-server ./main.go
+RUN GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-w -s" -o reports-server ./main.go
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /

--- a/charts/reports-server/README.md
+++ b/charts/reports-server/README.md
@@ -39,6 +39,7 @@ helm install reports-server --namespace reports-server --create-namespace report
 | serviceAccount.annotations | object | `{}` | Service account annotations |
 | serviceAccount.name | string | `""` | Service account name (required if `serviceAccount.create` is `false`) |
 | podAnnotations | object | `{}` | Pod annotations |
+| commonLabels | object | `{}` | Labels to add to resources managed by the chart |
 | podSecurityContext | object | `{"fsGroup":2000}` | Pod security context |
 | podEnv | object | `{}` | Provide additional environment variables to the pods. Map with the same format as kubernetes deployment spec's env. |
 | securityContext | object | See [values.yaml](values.yaml) | Container security context |
@@ -85,7 +86,7 @@ helm install reports-server --namespace reports-server --create-namespace report
 | config.db.sslrootcert | string | `""` | Database SSL root cert |
 | config.db.sslkey | string | `""` | Database SSL key |
 | config.db.sslcert | string | `""` | Database SSL cert |
-| apiServicesManagement.enabled | bool | `true` | Create a helm hooks delete api services on uninstall |
+| apiServicesManagement.enabled | bool | `true` | Create a helm hooks to delete api services on uninstall |
 | apiServicesManagement.installApiServices | object | `{"enabled":true,"installEphemeralReportsService":true}` | Install api services in manifest |
 | apiServicesManagement.installApiServices.enabled | bool | `true` | Store reports in reports-server |
 | apiServicesManagement.installApiServices.installEphemeralReportsService | bool | `true` | Store ephemeral reports in reports-server |

--- a/charts/reports-server/templates/_helpers.tpl
+++ b/charts/reports-server/templates/_helpers.tpl
@@ -35,6 +35,9 @@ Common labels
 */}}
 {{- define "reports-server.labels" -}}
 helm.sh/chart: {{ include "reports-server.chart" . }}
+{{- with .Values.commonLabels }}
+{{- toYaml .  }}
+{{- end }}
 {{ include "reports-server.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
@@ -46,6 +49,14 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "reports-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "reports-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "reports-server.commonLabels" -}}
 app.kubernetes.io/name: {{ include "reports-server.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/reports-server/templates/_helpers.tpl
+++ b/charts/reports-server/templates/_helpers.tpl
@@ -35,8 +35,8 @@ Common labels
 */}}
 {{- define "reports-server.labels" -}}
 helm.sh/chart: {{ include "reports-server.chart" . }}
-{{- with .Values.commonLabels }}
-{{- toYaml .  }}
+{{- if .Values.commonLabels }}
+{{ include "reports-server.commonLabels" . }}
 {{- end }}
 {{ include "reports-server.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
@@ -57,8 +57,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Common labels
 */}}
 {{- define "reports-server.commonLabels" -}}
-app.kubernetes.io/name: {{ include "reports-server.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+{{- with .Values.commonLabels }}
+{{- toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/reports-server/templates/cluster-roles.yaml
+++ b/charts/reports-server/templates/cluster-roles.yaml
@@ -28,7 +28,6 @@ rules:
     - namespaces
   verbs:
     - get
-{{- if .Values.apiServicesManagement.enabled }}
 - apiGroups:
     - apiregistration.k8s.io
   resources:
@@ -47,7 +46,6 @@ rules:
   resourceNames:
     - v1.reports.kyverno.io
     - v1alpha2.wgpolicyk8s.io
-{{- end }}
 - apiGroups:
     - wgpolicyk8s.io
   resources:

--- a/charts/reports-server/templates/deployment.yaml
+++ b/charts/reports-server/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "reports-server.selectorLabels" . | nindent 8 }}
+        {{- include "reports-server.labels" . | nindent 8 }}
     spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
@@ -45,20 +45,15 @@ spec:
             {{- end }}
             - --etcdEndpoints=https://etcd-0.etcd.{{ $.Release.Namespace }}:2379,https://etcd-1.etcd.{{ $.Release.Namespace }}:2379,https://etcd-2.etcd.{{ $.Release.Namespace }}:2379
             {{- else }}
-            - --dbhost=$(DB_HOST)
-            - --dbport=$(DB_PORT)
-            - --dbuser=$(DB_USER)
-            - --dbpassword=$(DB_PASSWORD)
-            - --dbname=$(DB_DATABASE)
             - --dbsslmode={{ .Values.config.db.sslmode }}
             - --dbsslrootcert={{ .Values.config.db.sslrootcert }}
             - --dbsslkey={{ .Values.config.db.sslkey }}
             - --dbsslcert={{ .Values.config.db.sslcert }}
+            {{- end }}
             - --servicename={{ include "reports-server.fullname" . }}
             - --servicens={{ $.Release.Namespace }}
             - --storereports={{ .Values.apiServicesManagement.installApiServices.enabled }}
             - --storeephemeralreports={{ .Values.apiServicesManagement.installApiServices.installEphemeralReportsService }}
-            {{- end }}
             - --cert-dir=/tmp
             - --secure-port=4443
             {{- if .Values.metrics.enabled }}

--- a/charts/reports-server/templates/hooks/pre-delete-api-service-cleanup.yaml
+++ b/charts/reports-server/templates/hooks/pre-delete-api-service-cleanup.yaml
@@ -19,10 +19,11 @@ spec:
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.apiServicesManagement.podLabels }}
       labels:
+      {{- with .Values.apiServicesManagement.podLabels }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "reports-server.labels" . | nindent 8 }}
     spec:
       serviceAccount: {{ include "reports-server.serviceAccountName" . }}
       {{- with .Values.apiServicesManagement.podSecurityContext }}

--- a/charts/reports-server/templates/pod-disruption-budget.yaml
+++ b/charts/reports-server/templates/pod-disruption-budget.yaml
@@ -4,6 +4,8 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ include "reports-server.fullname" . }}
   namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "reports-server.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/reports-server/values.yaml
+++ b/charts/reports-server/values.yaml
@@ -55,6 +55,9 @@ serviceAccount:
 # -- Pod annotations
 podAnnotations: {}
 
+# -- Labels to add to resources managed by the chart
+commonLabels: {}
+
 # -- Pod security context
 podSecurityContext:
   fsGroup: 2000
@@ -227,7 +230,7 @@ config:
     sslcert: ""
 
 apiServicesManagement:
-  # -- Create a helm hooks delete api services on uninstall
+  # -- Create a helm hooks to delete api services on uninstall
   enabled: true
 
   # -- Install api services in manifest

--- a/config/install-etcd.yaml
+++ b/config/install-etcd.yaml
@@ -260,8 +260,11 @@ spec:
   template:
     metadata:
       labels:
+        helm.sh/chart: reports-server-0.1.3
         app.kubernetes.io/name: reports-server
         app.kubernetes.io/instance: reports-server
+        app.kubernetes.io/version: "v0.1.3"
+        app.kubernetes.io/managed-by: Helm
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: reports-server
@@ -273,6 +276,10 @@ spec:
             - --etcd
             - --etcdSkipTLS
             - --etcdEndpoints=https://etcd-0.etcd.reports-server:2379,https://etcd-1.etcd.reports-server:2379,https://etcd-2.etcd.reports-server:2379
+            - --servicename=reports-server
+            - --servicens=reports-server
+            - --storereports=true
+            - --storeephemeralreports=true
             - --cert-dir=/tmp
             - --secure-port=4443
             - --authorization-always-allow-paths=/metrics

--- a/config/install-etcd.yaml
+++ b/config/install-etcd.yaml
@@ -9,6 +9,12 @@ kind: PodDisruptionBudget
 metadata:
   name: reports-server
   namespace: reports-server
+  labels:
+    helm.sh/chart: reports-server-0.1.3
+    app.kubernetes.io/name: reports-server
+    app.kubernetes.io/instance: reports-server
+    app.kubernetes.io/version: "v0.1.3"
+    app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -322,8 +322,11 @@ spec:
   template:
     metadata:
       labels:
+        helm.sh/chart: reports-server-0.1.3
         app.kubernetes.io/name: reports-server
         app.kubernetes.io/instance: reports-server
+        app.kubernetes.io/version: "v0.1.3"
+        app.kubernetes.io/managed-by: Helm
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: reports-server
@@ -332,11 +335,6 @@ spec:
       containers:
         - name: reports-server
           args:
-            - --dbhost=$(DB_HOST)
-            - --dbport=$(DB_PORT)
-            - --dbuser=$(DB_USER)
-            - --dbpassword=$(DB_PASSWORD)
-            - --dbname=$(DB_DATABASE)
             - --dbsslmode=disable
             - --dbsslrootcert=
             - --dbsslkey=

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -9,6 +9,12 @@ kind: PodDisruptionBudget
 metadata:
   name: reports-server
   namespace: reports-server
+  labels:
+    helm.sh/chart: reports-server-0.1.3
+    app.kubernetes.io/name: reports-server
+    app.kubernetes.io/instance: reports-server
+    app.kubernetes.io/version: "v0.1.3"
+    app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Fix: allow env variable injection to work for database secrets
Fix: Add missing labels to pdb
Fix: apiservice management permissions
 should always be required due to automatic migration code
Fix: some required command line options were not being added when using etcd as a database
Feat: Add commonLabels input variable, which allows adding arbitrary labels to all resources managed by the chart