### PR TITLE
feat(migration): enhance skipMigration logic and update README for clarity

### DIFF
--- a/charts/reports-server/README.md
+++ b/charts/reports-server/README.md
@@ -74,7 +74,7 @@ helm install reports-server --namespace reports-server --create-namespace report
 | affinity | object | `{}` | Affinity |
 | service.type | string | `"ClusterIP"` | Service type |
 | service.port | int | `443` | Service port |
-| config.skipMigration | bool | `false` | Skip database migration on startup |
+| config.skipMigration | bool | `false` | Skip database migration on startup. By default, migration is automatically skipped if reports already exist in the database. |
 | config.etcd.enabled | bool | `false` |  |
 | config.etcd.endpoints | string | `nil` |  |
 | config.etcd.insecure | bool | `true` |  |

--- a/pkg/app/opts/options.go
+++ b/pkg/app/opts/options.go
@@ -92,7 +92,7 @@ func (o *Options) Flags() (fs flag.NamedFlagSets) {
 	msfs.BoolVar(&o.StoreReports, "storereports", true, "Whether or not to store and manage Policy Reports.")
 	msfs.BoolVar(&o.StoreOpenreports, "storeopenreports", true, "Whether or not to store and manage Open Reports.")
 	msfs.BoolVar(&o.StoreEphemeralReports, "storeephemeralreports", true, "Whether or not to store and manage Ephemeral Reports.")
-	msfs.BoolVar(&o.SkipMigration, "skipmigration", false, "Skip database migration on startup.")
+	msfs.BoolVar(&o.SkipMigration, "skipmigration", false, "Skip database migration on startup. By default, migration is automatically skipped if reports already exist in the database.")
 
 	o.SecureServing.AddFlags(fs.FlagSet("apiserver secure serving"))
 	o.Authentication.AddFlags(fs.FlagSet("apiserver authentication"))

--- a/pkg/server/migration.go
+++ b/pkg/server/migration.go
@@ -15,7 +15,61 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2"
 	"sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/generated/v1alpha2/clientset/versioned"
+
+	"github.com/kyverno/reports-server/pkg/api"
 )
+
+func (c *Config) shouldSkipMigration(ctx context.Context) bool {
+	if c.SkipMigration {
+		return true
+	}
+
+	if c.APIServices.StoreReports {
+		cpolrs, err := c.Store.ClusterPolicyReports().List(ctx)
+		if err == nil && len(cpolrs) > 0 {
+			for _, r := range cpolrs {
+				if r.Annotations[api.ServedByReportsServerAnnotation] == api.ServedByReportsServerValue {
+					klog.Info("found existing reports in database with reports-server annotation, skipping migration")
+					return true
+				}
+			}
+		}
+
+		polrs, err := c.Store.PolicyReports().List(ctx, "")
+		if err == nil && len(polrs) > 0 {
+			for _, r := range polrs {
+				if r.Annotations[api.ServedByReportsServerAnnotation] == api.ServedByReportsServerValue {
+					klog.Info("found existing reports in database with reports-server annotation, skipping migration")
+					return true
+				}
+			}
+		}
+	}
+
+	if c.APIServices.StoreEphemeralReports {
+		cephrs, err := c.Store.ClusterEphemeralReports().List(ctx)
+		if err == nil && len(cephrs) > 0 {
+			for _, r := range cephrs {
+				if r.Annotations[api.ServedByReportsServerAnnotation] == api.ServedByReportsServerValue {
+					klog.Info("found existing reports in database with reports-server annotation, skipping migration")
+					return true
+				}
+			}
+		}
+
+		ephrs, err := c.Store.EphemeralReports().List(ctx, "")
+		if err == nil && len(ephrs) > 0 {
+			for _, r := range ephrs {
+				if r.Annotations[api.ServedByReportsServerAnnotation] == api.ServedByReportsServerValue {
+					klog.Info("found existing reports in database with reports-server annotation, skipping migration")
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
 
 func (c *Config) migration(ctx context.Context) error {
 	kyvernoClient, err := kyverno.NewForConfig(c.Rest)
@@ -28,13 +82,15 @@ func (c *Config) migration(ctx context.Context) error {
 	}
 	workerChan := make(chan struct{}, numWorkers)
 
+	skipMigration := c.shouldSkipMigration(ctx)
+
 	if c.APIServices.StoreReports {
 		cpolrs, err := policyClient.Wgpolicyk8sV1alpha2().ClusterPolicyReports().List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return nil
 		}
 
-		if !c.SkipMigration {
+		if !skipMigration {
 			cpolrWg := &sync.WaitGroup{}
 			cpolrWg.Add(len(cpolrs.Items))
 			for _, r := range cpolrs.Items {
@@ -64,7 +120,7 @@ func (c *Config) migration(ctx context.Context) error {
 			return nil
 		}
 
-		if !c.SkipMigration {
+		if !skipMigration {
 			polrWg := &sync.WaitGroup{}
 			polrWg.Add(len(polrs.Items))
 			for _, r := range polrs.Items {
@@ -97,7 +153,7 @@ func (c *Config) migration(ctx context.Context) error {
 			return nil
 		}
 
-		if !c.SkipMigration {
+		if !skipMigration {
 			cephrWg := &sync.WaitGroup{}
 			cephrWg.Add(len(cephrs.Items))
 			for _, r := range cephrs.Items {
@@ -127,7 +183,7 @@ func (c *Config) migration(ctx context.Context) error {
 			return nil
 		}
 
-		if !c.SkipMigration {
+		if !skipMigration {
 			ephrWg := &sync.WaitGroup{}
 			ephrWg.Add(len(ephrs.Items))
 			for _, r := range ephrs.Items {
@@ -169,7 +225,7 @@ func (c *Config) migrateReport(ctx context.Context, kyvernoClient kyverno.Interf
 	case v1alpha2.ClusterPolicyReport:
 		err := c.Store.ClusterPolicyReports().Create(ctx, &r)
 		if err != nil {
-			klog.Errorf("failed to mirgrate report of kind %s %s: %s", r.GroupVersionKind().String(), r.Name, err)
+			klog.Errorf("failed to migrate report of kind %s %s: %s", r.GroupVersionKind().String(), r.Name, err)
 		}
 		// Update annotation in Kubernetes before deleting so watchers can identify it
 		_, err = policyClient.Wgpolicyk8sV1alpha2().ClusterPolicyReports().Update(ctx, &r, metav1.UpdateOptions{})
@@ -182,7 +238,7 @@ func (c *Config) migrateReport(ctx context.Context, kyvernoClient kyverno.Interf
 	case v1alpha2.PolicyReport:
 		err := c.Store.PolicyReports().Create(ctx, &r)
 		if err != nil {
-			klog.Errorf("failed to mirgrate report of kind %s %s: %s", r.GroupVersionKind().String(), r.Name, err)
+			klog.Errorf("failed to migrate report of kind %s %s: %s", r.GroupVersionKind().String(), r.Name, err)
 		}
 		// Update annotation in Kubernetes before deleting so watchers can identify it
 		_, err = policyClient.Wgpolicyk8sV1alpha2().PolicyReports(r.Namespace).Update(ctx, &r, metav1.UpdateOptions{})
@@ -195,7 +251,7 @@ func (c *Config) migrateReport(ctx context.Context, kyvernoClient kyverno.Interf
 	case v1.ClusterEphemeralReport:
 		err := c.Store.ClusterEphemeralReports().Create(ctx, &r)
 		if err != nil {
-			klog.Errorf("failed to mirgrate report of kind %s %s: %s", r.GroupVersionKind().String(), r.Name, err)
+			klog.Errorf("failed to migrate report of kind %s %s: %s", r.GroupVersionKind().String(), r.Name, err)
 		}
 		// Update annotation in Kubernetes before deleting so watchers can identify it
 		_, err = kyvernoClient.ReportsV1().ClusterEphemeralReports().Update(ctx, &r, metav1.UpdateOptions{})
@@ -208,7 +264,7 @@ func (c *Config) migrateReport(ctx context.Context, kyvernoClient kyverno.Interf
 	case v1.EphemeralReport:
 		err := c.Store.EphemeralReports().Create(ctx, &r)
 		if err != nil {
-			klog.Errorf("failed to mirgrate report of kind %s %s: %s", r.GroupVersionKind().String(), r.Name, err)
+			klog.Errorf("failed to migrate report of kind %s %s: %s", r.GroupVersionKind().String(), r.Name, err)
 		}
 		// Update annotation in Kubernetes before deleting so watchers can identify it
 		_, err = kyvernoClient.ReportsV1().EphemeralReports(r.Namespace).Update(ctx, &r, metav1.UpdateOptions{})


### PR DESCRIPTION
Fixes 
- #323

Added automatic detection to check if reports already exist in the database with the reports-server annotation. When detected, migration is skipped without requiring user intervention.

The server now queries the database on startup and looks for the `kyverno.reports-server.io/served-by: reports-server` annotation on existing reports. If found, it means a previous instance already migrated the data so we skip it. Keeps the `--skipmigration` flag for manual override if needed.

### Changes
- Added `shouldSkipMigration()` helper that checks database for reports with the annotation
- Modified migration logic to use automatic detection instead of only checking the flag
- Updated docs to mention automatic detection behavior
