### PR TITLE
fix: add periodic APIService reconciler

### DIFF
--- a/pkg/app/opts/options.go
+++ b/pkg/app/opts/options.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/kyverno/reports-server/pkg/api"
 	generatedopenapi "github.com/kyverno/reports-server/pkg/api/generated/openapi"
@@ -57,6 +58,9 @@ type Options struct {
 	StoreEphemeralReports bool
 	StoreOpenreports      bool
 
+	// reconciler config
+	APIServiceReconcileInterval time.Duration
+
 	// Only to be used to for testing
 	DisableAuthForTesting bool
 }
@@ -93,6 +97,7 @@ func (o *Options) Flags() (fs flag.NamedFlagSets) {
 	msfs.BoolVar(&o.StoreOpenreports, "storeopenreports", true, "Whether or not to store and manage Open Reports.")
 	msfs.BoolVar(&o.StoreEphemeralReports, "storeephemeralreports", true, "Whether or not to store and manage Ephemeral Reports.")
 	msfs.BoolVar(&o.SkipMigration, "skipmigration", false, "Skip database migration on startup.")
+	msfs.DurationVar(&o.APIServiceReconcileInterval, "apiservicereconcileinterval", 10*time.Second, "Interval between APIService reconciliation runs.")
 
 	o.SecureServing.AddFlags(fs.FlagSet("apiserver secure serving"))
 	o.Authentication.AddFlags(fs.FlagSet("apiserver authentication"))

--- a/pkg/app/policyserver.go
+++ b/pkg/app/policyserver.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -78,6 +79,13 @@ func runCommand(o *opts.Options, stopCh <-chan struct{}) error {
 		}
 	}()
 
+	reconcilerCtx, reconcilerCancel := context.WithCancel(context.Background())
+	reconcilerDone := make(chan struct{})
+	go func() {
+		config.StartAPIServiceReconciler(reconcilerCtx)
+		close(reconcilerDone)
+	}()
+
 	sigChan := make(chan os.Signal, 1)
 	done := make(chan bool, 1)
 
@@ -85,6 +93,8 @@ func runCommand(o *opts.Options, stopCh <-chan struct{}) error {
 
 	go func() {
 		<-sigChan
+		reconcilerCancel()
+		<-reconcilerDone
 		if err := config.CleanupApiServices(); err != nil {
 			klog.ErrorS(err, "failed to cleanup api-services during shutdown")
 		}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/kyverno/reports-server/pkg/api"
@@ -211,6 +212,28 @@ func (c *Config) installApiServices() error {
 	}
 
 	return nil
+}
+
+func (c *Config) StartAPIServiceReconciler(ctx context.Context) {
+	if !c.APIServices.StoreReports && !c.APIServices.StoreEphemeralReports && !c.APIServices.StoreOpenreports {
+		klog.Info("No APIServices enabled, skipping reconciler")
+		return
+	}
+	const reconcileInterval = 10 * time.Second
+	ticker := time.NewTicker(reconcileInterval)
+	defer ticker.Stop()
+	klog.Info("Starting APIService reconciler")
+	for {
+		select {
+		case <-ctx.Done():
+			klog.Info("Stopping APIService reconciler")
+			return
+		case <-ticker.C:
+			if err := c.installApiServices(); err != nil {
+				klog.Errorf("APIService reconciliation failed: %v", err)
+			}
+		}
+	}
 }
 
 func (c *Config) toLocalApiService(apiSvcName string, client apiregistrationv1client.ApiregistrationV1Client) error {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -36,8 +36,9 @@ type Config struct {
 	DBconfig      *db.PostgresConfig
 	ClusterName   string
 	APIServices   APIServices
-	Store         storage.Interface
-	SkipMigration bool
+	Store                       storage.Interface
+	SkipMigration               bool
+	APIServiceReconcileInterval time.Duration
 }
 
 func NewServerConfig(o opts.Options) (*Config, error) {
@@ -93,8 +94,9 @@ func NewServerConfig(o opts.Options) (*Config, error) {
 		DBconfig:      dbconfig,
 		ClusterName:   o.ClusterName,
 		APIServices:   apiservices,
-		Store:         store,
-		SkipMigration: o.SkipMigration,
+		Store:                       store,
+		SkipMigration:               o.SkipMigration,
+		APIServiceReconcileInterval: o.APIServiceReconcileInterval,
 	}
 
 	return config, nil
@@ -219,8 +221,7 @@ func (c *Config) StartAPIServiceReconciler(ctx context.Context) {
 		klog.Info("No APIServices enabled, skipping reconciler")
 		return
 	}
-	const reconcileInterval = 10 * time.Second
-	ticker := time.NewTicker(reconcileInterval)
+	ticker := time.NewTicker(c.APIServiceReconcileInterval)
 	defer ticker.Stop()
 	klog.Info("Starting APIService reconciler")
 	for {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -194,6 +194,7 @@ func applyReportsServerAnnotation(o metav1.Object) {
 	if a == nil {
 		a = make(map[string]string)
 	}
+
 	a[api.ServedByReportsServerAnnotation] = api.ServedByReportsServerValue
 	o.SetAnnotations(a)
 }

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -29,13 +29,13 @@ import (
 const numWorkers = 50
 
 type Config struct {
-	Apiserver     *genericapiserver.Config
-	Rest          *rest.Config
-	Embedded      bool
-	EtcdConfig    *etcd.EtcdConfig
-	DBconfig      *db.PostgresConfig
-	ClusterName   string
-	APIServices   APIServices
+	Apiserver                   *genericapiserver.Config
+	Rest                        *rest.Config
+	Embedded                    bool
+	EtcdConfig                  *etcd.EtcdConfig
+	DBconfig                    *db.PostgresConfig
+	ClusterName                 string
+	APIServices                 APIServices
 	Store                       storage.Interface
 	SkipMigration               bool
 	APIServiceReconcileInterval time.Duration
@@ -87,13 +87,13 @@ func NewServerConfig(o opts.Options) (*Config, error) {
 	}
 
 	config := &Config{
-		Apiserver:     apiserver,
-		Rest:          restConfig,
-		Embedded:      o.Etcd,
-		EtcdConfig:    &o.EtcdConfig,
-		DBconfig:      dbconfig,
-		ClusterName:   o.ClusterName,
-		APIServices:   apiservices,
+		Apiserver:                   apiserver,
+		Rest:                        restConfig,
+		Embedded:                    o.Etcd,
+		EtcdConfig:                  &o.EtcdConfig,
+		DBconfig:                    dbconfig,
+		ClusterName:                 o.ClusterName,
+		APIServices:                 apiservices,
 		Store:                       store,
 		SkipMigration:               o.SkipMigration,
 		APIServiceReconcileInterval: o.APIServiceReconcileInterval,


### PR DESCRIPTION
During rolling updates, the running pod cleanup hook patches `spec.service` to null on all APIServices.
However, the running pods have no way to detect or repair this since `installApiServices()` only ran once at startup, making aggregated report resources unavailable until restart in a sort of chicken-egg scenario.

Fixes: #327 
