### PR TITLE
refactor: handle skipping migrations properly without relying on user input

### DIFF
--- a/pkg/server/migration.go
+++ b/pkg/server/migration.go
@@ -7,13 +7,13 @@ import (
 	v1 "github.com/kyverno/kyverno/api/reports/v1"
 	kyverno "github.com/kyverno/kyverno/pkg/clients/kyverno"
 	"github.com/kyverno/reports-server/pkg/utils"
-	openreportsv1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
-	openreportsclient "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 	watchtools "k8s.io/client-go/tools/watch"
 	"k8s.io/klog/v2"
+	openreportsv1alpha1 "openreports.io/apis/openreports.io/v1alpha1"
+	openreportsclient "openreports.io/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
 	"sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2"
 	"sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/generated/v1alpha2/clientset/versioned"
 )
@@ -87,7 +87,7 @@ func (c *Config) handleMigrateWgPolicyApis(ctx context.Context, policyClient *ve
 			return policyClient.Wgpolicyk8sV1alpha2().ClusterPolicyReports().Watch(ctx, options)
 		},
 	}
-	cpolrWatchInterface, err := watchtools.NewRetryWatcherWithContext(ctx, cpolrs.GetResourceVersion(), cpolrWatcher)
+	cpolrWatchInterface, err := watchtools.NewRetryWatcher(cpolrs.GetResourceVersion(), cpolrWatcher)
 	if err != nil {
 		return err
 	}
@@ -126,7 +126,7 @@ func (c *Config) handleMigrateWgPolicyApis(ctx context.Context, policyClient *ve
 			return policyClient.Wgpolicyk8sV1alpha2().PolicyReports("").Watch(ctx, options)
 		},
 	}
-	polrWatchInterface, err := watchtools.NewRetryWatcherWithContext(ctx, polrs.GetResourceVersion(), polrWatcher)
+	polrWatchInterface, err := watchtools.NewRetryWatcher(polrs.GetResourceVersion(), polrWatcher)
 	if err != nil {
 		return err
 	}
@@ -166,7 +166,7 @@ func (c *Config) handleMigrateEphrApis(ctx context.Context, kyvernoClient kyvern
 			return kyvernoClient.ReportsV1().ClusterEphemeralReports().Watch(ctx, options)
 		},
 	}
-	cephrWatchInterface, err := watchtools.NewRetryWatcherWithContext(ctx, cephrs.GetResourceVersion(), cephrWatcher)
+	cephrWatchInterface, err := watchtools.NewRetryWatcher(cephrs.GetResourceVersion(), cephrWatcher)
 	if err != nil {
 		return err
 	}
@@ -205,7 +205,7 @@ func (c *Config) handleMigrateEphrApis(ctx context.Context, kyvernoClient kyvern
 			return kyvernoClient.ReportsV1().EphemeralReports("").Watch(ctx, options)
 		},
 	}
-	ephrWatchInterface, err := watchtools.NewRetryWatcherWithContext(ctx, ephrs.GetResourceVersion(), ephrWatcher)
+	ephrWatchInterface, err := watchtools.NewRetryWatcher(ephrs.GetResourceVersion(), ephrWatcher)
 	if err != nil {
 		return err
 	}
@@ -245,7 +245,7 @@ func (c *Config) handleMigrateOpenreportsApis(ctx context.Context, orClient open
 			return orClient.ClusterReports().Watch(ctx, options)
 		},
 	}
-	crepsWatchInterface, err := watchtools.NewRetryWatcherWithContext(ctx, creps.GetResourceVersion(), crepsWatcher)
+	crepsWatchInterface, err := watchtools.NewRetryWatcher(creps.GetResourceVersion(), crepsWatcher)
 	if err != nil {
 		return err
 	}
@@ -283,7 +283,7 @@ func (c *Config) handleMigrateOpenreportsApis(ctx context.Context, orClient open
 			return orClient.Reports("").Watch(ctx, options)
 		},
 	}
-	reportsWatchInterface, err := watchtools.NewRetryWatcherWithContext(ctx, reports.GetResourceVersion(), reportsWatcher)
+	reportsWatchInterface, err := watchtools.NewRetryWatcher(reports.GetResourceVersion(), reportsWatcher)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/migration.go
+++ b/pkg/server/migration.go
@@ -6,6 +6,9 @@ import (
 
 	v1 "github.com/kyverno/kyverno/api/reports/v1"
 	kyverno "github.com/kyverno/kyverno/pkg/clients/kyverno"
+	"github.com/kyverno/reports-server/pkg/utils"
+	openreportsv1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
+	openreportsclient "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
@@ -24,142 +27,277 @@ func (c *Config) migration(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	orClient, err := openreportsclient.NewForConfig(c.Rest)
+	if err != nil {
+		return err
+	}
 	workerChan := make(chan struct{}, numWorkers)
 
 	if c.APIServices.StoreReports {
-		cpolrs, err := policyClient.Wgpolicyk8sV1alpha2().ClusterPolicyReports().List(ctx, metav1.ListOptions{})
-		if err != nil {
-			return nil
+		if err := c.handleMigrateWgPolicyApis(ctx, policyClient, workerChan); err != nil {
+			klog.Errorf("unable to migrate wgpolicyk8s reports: %s", err.Error())
 		}
-
-		if !c.SkipMigration {
-			cpolrWg := &sync.WaitGroup{}
-			cpolrWg.Add(len(cpolrs.Items))
-			for _, r := range cpolrs.Items {
-				applyReportsServerAnnotation(&r)
-				go c.migrateReport(ctx, kyvernoClient, policyClient, workerChan, cpolrWg, r)
-			}
-			cpolrWg.Wait()
-		}
-
-		err = c.Store.ClusterPolicyReports().SetResourceVersion(cpolrs.ResourceVersion)
-		if err != nil {
-			return err
-		}
-		cpolrWatcher := &cache.ListWatch{
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return policyClient.Wgpolicyk8sV1alpha2().ClusterPolicyReports().Watch(ctx, options)
-			},
-		}
-		cpolrWatchInterface, err := watchtools.NewRetryWatcher(cpolrs.GetResourceVersion(), cpolrWatcher)
-		if err != nil {
-			return err
-		}
-		go c.watchCpolr(ctx, cpolrWatchInterface)
-
-		polrs, err := policyClient.Wgpolicyk8sV1alpha2().PolicyReports("").List(ctx, metav1.ListOptions{})
-		if err != nil {
-			return nil
-		}
-
-		if !c.SkipMigration {
-			polrWg := &sync.WaitGroup{}
-			polrWg.Add(len(polrs.Items))
-			for _, r := range polrs.Items {
-				applyReportsServerAnnotation(&r)
-				go c.migrateReport(ctx, kyvernoClient, policyClient, workerChan, polrWg, r)
-			}
-			polrWg.Wait()
-		}
-
-		err = c.Store.PolicyReports().SetResourceVersion(polrs.ResourceVersion)
-		if err != nil {
-			return err
-		}
-
-		polrWatcher := &cache.ListWatch{
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return policyClient.Wgpolicyk8sV1alpha2().PolicyReports("").Watch(ctx, options)
-			},
-		}
-		polrWatchInterface, err := watchtools.NewRetryWatcher(polrs.GetResourceVersion(), polrWatcher)
-		if err != nil {
-			return err
-		}
-		go c.watchPolr(ctx, polrWatchInterface)
 	}
 
 	if c.APIServices.StoreEphemeralReports {
-		cephrs, err := kyvernoClient.ReportsV1().ClusterEphemeralReports().List(ctx, metav1.ListOptions{})
-		if err != nil {
-			return nil
+		if err := c.handleMigrateEphrApis(ctx, kyvernoClient, workerChan); err != nil {
+			klog.Errorf("unable to migrate ephemeral reports: %s", err.Error())
 		}
-
-		if !c.SkipMigration {
-			cephrWg := &sync.WaitGroup{}
-			cephrWg.Add(len(cephrs.Items))
-			for _, r := range cephrs.Items {
-				applyReportsServerAnnotation(&r)
-				go c.migrateReport(ctx, kyvernoClient, policyClient, workerChan, cephrWg, r)
-			}
-			cephrWg.Wait()
-		}
-
-		err = c.Store.ClusterEphemeralReports().SetResourceVersion(cephrs.ResourceVersion)
-		if err != nil {
-			return err
-		}
-		cephrWatcher := &cache.ListWatch{
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return kyvernoClient.ReportsV1().ClusterEphemeralReports().Watch(ctx, options)
-			},
-		}
-		cephrWatchInterface, err := watchtools.NewRetryWatcher(cephrs.GetResourceVersion(), cephrWatcher)
-		if err != nil {
-			return err
-		}
-		go c.watchCephr(ctx, cephrWatchInterface)
-
-		ephrs, err := kyvernoClient.ReportsV1().EphemeralReports("").List(ctx, metav1.ListOptions{})
-		if err != nil {
-			return nil
-		}
-
-		if !c.SkipMigration {
-			ephrWg := &sync.WaitGroup{}
-			ephrWg.Add(len(ephrs.Items))
-			for _, r := range ephrs.Items {
-				applyReportsServerAnnotation(&r)
-				go c.migrateReport(ctx, kyvernoClient, policyClient, workerChan, ephrWg, r)
-			}
-			ephrWg.Wait()
-		}
-
-		err = c.Store.EphemeralReports().SetResourceVersion(ephrs.ResourceVersion)
-		if err != nil {
-			return err
-		}
-		ephrWatcher := &cache.ListWatch{
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return kyvernoClient.ReportsV1().EphemeralReports("").Watch(ctx, options)
-			},
-		}
-		ephrWatchInterface, err := watchtools.NewRetryWatcher(ephrs.GetResourceVersion(), ephrWatcher)
-		if err != nil {
-			return err
-		}
-		go c.watchEphr(ctx, ephrWatchInterface)
 	}
-	// rv, err := strconv.ParseUint(c.Store.UseResourceVersion(), 10, 64)
-	// if err != nil {
-	// 	return err
-	// }
-	// // use leave some versions for resources added using watchers
-	// return c.Store.SetResourceVersion(fmt.Sprint((rv + 9999)))
+
+	if c.APIServices.StoreOpenreports {
+		if err := c.handleMigrateOpenreportsApis(ctx, orClient, workerChan); err != nil {
+			klog.Errorf("unable to migrate ephemeral reports: %s", err.Error())
+		}
+	}
+
 	return nil
 }
 
-func (c *Config) migrateReport(ctx context.Context, kyvernoClient kyverno.Interface, policyClient versioned.Interface, workerChan chan struct{}, wg *sync.WaitGroup, report interface{}) {
+func (c *Config) handleMigrateWgPolicyApis(ctx context.Context, policyClient *versioned.Clientset, workerChan chan struct{}) error {
+	cpolrs, err := policyClient.Wgpolicyk8sV1alpha2().ClusterPolicyReports().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	count, err := c.Store.ClusterPolicyReports().Count(ctx)
+	if err != nil {
+		klog.Errorf("error listing the count of %s from the data store. falling back to the skip migration flag", utils.ClusterPolicyReportsGR)
+		count = len(cpolrs.Items)
+	}
+
+	if count != len(cpolrs.Items) {
+		if !c.SkipMigration {
+			wg := &sync.WaitGroup{}
+			wg.Add(len(cpolrs.Items))
+			for _, r := range cpolrs.Items {
+				applyReportsServerAnnotation(&r)
+				go c.migrateReport(ctx, nil, policyClient, nil, workerChan, wg, r)
+			}
+			wg.Wait()
+		}
+	}
+
+	err = c.Store.ClusterPolicyReports().SetResourceVersion(cpolrs.ResourceVersion)
+	if err != nil {
+		return err
+	}
+
+	cpolrWatcher := &cache.ListWatch{
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return policyClient.Wgpolicyk8sV1alpha2().ClusterPolicyReports().Watch(ctx, options)
+		},
+	}
+	cpolrWatchInterface, err := watchtools.NewRetryWatcherWithContext(ctx, cpolrs.GetResourceVersion(), cpolrWatcher)
+	if err != nil {
+		return err
+	}
+	go c.watchReport(ctx, cpolrWatchInterface)
+
+	polrs, err := policyClient.Wgpolicyk8sV1alpha2().PolicyReports("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		klog.Errorf("error listing %s from the Kubernetes API", utils.PolicyReportsGR)
+		return err
+	}
+	count, err = c.Store.PolicyReports().Count(ctx)
+	if err != nil {
+		klog.Errorf("error listing the count of %s from the data store. falling back to the skip migration flag", utils.PolicyReportsGR)
+		count = len(polrs.Items)
+	}
+
+	if count != len(polrs.Items) {
+		if !c.SkipMigration {
+			wg := &sync.WaitGroup{}
+			wg.Add(len(polrs.Items))
+			for _, r := range polrs.Items {
+				applyReportsServerAnnotation(&r)
+				go c.migrateReport(ctx, nil, policyClient, nil, workerChan, wg, r)
+			}
+			wg.Wait()
+		}
+	}
+
+	err = c.Store.PolicyReports().SetResourceVersion(polrs.ResourceVersion)
+	if err != nil {
+		return err
+	}
+
+	polrWatcher := &cache.ListWatch{
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return policyClient.Wgpolicyk8sV1alpha2().PolicyReports("").Watch(ctx, options)
+		},
+	}
+	polrWatchInterface, err := watchtools.NewRetryWatcherWithContext(ctx, polrs.GetResourceVersion(), polrWatcher)
+	if err != nil {
+		return err
+	}
+	go c.watchReport(ctx, polrWatchInterface)
+	return nil
+}
+
+func (c *Config) handleMigrateEphrApis(ctx context.Context, kyvernoClient kyverno.Interface, workerChan chan struct{}) error {
+	cephrs, err := kyvernoClient.ReportsV1().ClusterEphemeralReports().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	count, err := c.Store.ClusterEphemeralReports().Count(ctx)
+	if err != nil {
+		klog.Errorf("error listing the count of %s from the data store. falling back to the skip migration flag", utils.ClusterEphemeralReportsGR)
+		count = len(cephrs.Items)
+	}
+
+	if count != len(cephrs.Items) {
+		if !c.SkipMigration {
+			wg := &sync.WaitGroup{}
+			wg.Add(len(cephrs.Items))
+			for _, r := range cephrs.Items {
+				applyReportsServerAnnotation(&r)
+				go c.migrateReport(ctx, kyvernoClient, nil, nil, workerChan, wg, r)
+			}
+			wg.Wait()
+		}
+	}
+
+	err = c.Store.ClusterEphemeralReports().SetResourceVersion(cephrs.ResourceVersion)
+	if err != nil {
+		return err
+	}
+	cephrWatcher := &cache.ListWatch{
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return kyvernoClient.ReportsV1().ClusterEphemeralReports().Watch(ctx, options)
+		},
+	}
+	cephrWatchInterface, err := watchtools.NewRetryWatcherWithContext(ctx, cephrs.GetResourceVersion(), cephrWatcher)
+	if err != nil {
+		return err
+	}
+	go c.watchReport(ctx, cephrWatchInterface)
+
+	ephrs, err := kyvernoClient.ReportsV1().EphemeralReports("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		klog.Errorf("error listing %s: %v", utils.EphemeralReportsGR, err)
+		return err
+	}
+	count, err = c.Store.EphemeralReports().Count(ctx)
+	if err != nil {
+		klog.Errorf("error listing the count of %s from the data store. falling back to the skip migration flag", utils.EphemeralReportsGR)
+		count = len(ephrs.Items)
+	}
+
+	if count != len(ephrs.Items) {
+		if !c.SkipMigration {
+			wg := &sync.WaitGroup{}
+			wg.Add(len(ephrs.Items))
+			for _, r := range ephrs.Items {
+				applyReportsServerAnnotation(&r)
+				// we don't the policyClient to be non nil because the ephemeral reports rely on kyvernoClient
+				go c.migrateReport(ctx, kyvernoClient, nil, nil, workerChan, wg, r)
+			}
+			wg.Wait()
+		}
+	}
+
+	err = c.Store.EphemeralReports().SetResourceVersion(ephrs.ResourceVersion)
+	if err != nil {
+		return err
+	}
+	ephrWatcher := &cache.ListWatch{
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return kyvernoClient.ReportsV1().EphemeralReports("").Watch(ctx, options)
+		},
+	}
+	ephrWatchInterface, err := watchtools.NewRetryWatcherWithContext(ctx, ephrs.GetResourceVersion(), ephrWatcher)
+	if err != nil {
+		return err
+	}
+	go c.watchReport(ctx, ephrWatchInterface)
+	return nil
+}
+
+func (c *Config) handleMigrateOpenreportsApis(ctx context.Context, orClient openreportsclient.OpenreportsV1alpha1Interface, workerChan chan struct{}) error {
+	creps, err := orClient.ClusterReports().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	count, err := c.Store.ClusterReports().Count(ctx)
+	if err != nil {
+		klog.Errorf("error listing the count of %s from the data store. falling back to the skip migration flag", utils.OpenreportsClusterReportGR)
+		count = len(creps.Items)
+	}
+
+	if count != len(creps.Items) {
+		if !c.SkipMigration {
+			wg := &sync.WaitGroup{}
+			wg.Add(len(creps.Items))
+			for _, r := range creps.Items {
+				applyReportsServerAnnotation(&r)
+				go c.migrateReport(ctx, nil, nil, orClient, workerChan, wg, r)
+			}
+			wg.Wait()
+		}
+	}
+
+	err = c.Store.ClusterReports().SetResourceVersion(creps.ResourceVersion)
+	if err != nil {
+		return err
+	}
+	crepsWatcher := &cache.ListWatch{
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return orClient.ClusterReports().Watch(ctx, options)
+		},
+	}
+	crepsWatchInterface, err := watchtools.NewRetryWatcherWithContext(ctx, creps.GetResourceVersion(), crepsWatcher)
+	if err != nil {
+		return err
+	}
+	go c.watchReport(ctx, crepsWatchInterface)
+
+	reports, err := orClient.Reports("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	count, err = c.Store.Reports().Count(ctx)
+	if err != nil {
+		klog.Errorf("error listing the count of %s from the data store. falling back to the skip migration flag", utils.OpenreportsReportGR)
+		count = len(reports.Items)
+	}
+
+	if count != len(reports.Items) {
+		if !c.SkipMigration {
+			wg := &sync.WaitGroup{}
+			wg.Add(len(reports.Items))
+			for _, r := range reports.Items {
+				applyReportsServerAnnotation(&r)
+				go c.migrateReport(ctx, nil, nil, orClient, workerChan, wg, r)
+			}
+			wg.Wait()
+		}
+	}
+
+	err = c.Store.Reports().SetResourceVersion(reports.ResourceVersion)
+	if err != nil {
+		return err
+	}
+
+	reportsWatcher := &cache.ListWatch{
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return orClient.Reports("").Watch(ctx, options)
+		},
+	}
+	reportsWatchInterface, err := watchtools.NewRetryWatcherWithContext(ctx, reports.GetResourceVersion(), reportsWatcher)
+	if err != nil {
+		return err
+	}
+	go c.watchReport(ctx, reportsWatchInterface)
+	return nil
+}
+
+func (c *Config) migrateReport(ctx context.Context,
+	kyvernoClient kyverno.Interface,
+	policyClient versioned.Interface,
+	orClient openreportsclient.OpenreportsV1alpha1Interface,
+	workerChan chan struct{},
+	wg *sync.WaitGroup, report any,
+) {
 	defer wg.Done()
 
 	// book a slot in the worker chan
@@ -168,7 +306,7 @@ func (c *Config) migrateReport(ctx context.Context, kyvernoClient kyverno.Interf
 	case v1alpha2.ClusterPolicyReport:
 		err := c.Store.ClusterPolicyReports().Create(ctx, &r)
 		if err != nil {
-			klog.Errorf("failed to mirgrate report of kind %s %s: %s", r.GroupVersionKind().String(), r.Name, err)
+			klog.Errorf("failed to migrate report of kind %s %s: %s", r.GroupVersionKind().String(), r.Name, err)
 		}
 		// Update annotation in Kubernetes before deleting so watchers can identify it
 		_, err = policyClient.Wgpolicyk8sV1alpha2().ClusterPolicyReports().Update(ctx, &r, metav1.UpdateOptions{})
@@ -181,7 +319,7 @@ func (c *Config) migrateReport(ctx context.Context, kyvernoClient kyverno.Interf
 	case v1alpha2.PolicyReport:
 		err := c.Store.PolicyReports().Create(ctx, &r)
 		if err != nil {
-			klog.Errorf("failed to mirgrate report of kind %s %s: %s", r.GroupVersionKind().String(), r.Name, err)
+			klog.Errorf("failed to migrate report of kind %s %s: %s", r.GroupVersionKind().String(), r.Name, err)
 		}
 		// Update annotation in Kubernetes before deleting so watchers can identify it
 		_, err = policyClient.Wgpolicyk8sV1alpha2().PolicyReports(r.Namespace).Update(ctx, &r, metav1.UpdateOptions{})
@@ -194,7 +332,7 @@ func (c *Config) migrateReport(ctx context.Context, kyvernoClient kyverno.Interf
 	case v1.ClusterEphemeralReport:
 		err := c.Store.ClusterEphemeralReports().Create(ctx, &r)
 		if err != nil {
-			klog.Errorf("failed to mirgrate report of kind %s %s: %s", r.GroupVersionKind().String(), r.Name, err)
+			klog.Errorf("failed to migrate report of kind %s %s: %s", r.GroupVersionKind().String(), r.Name, err)
 		}
 		// Update annotation in Kubernetes before deleting so watchers can identify it
 		_, err = kyvernoClient.ReportsV1().ClusterEphemeralReports().Update(ctx, &r, metav1.UpdateOptions{})
@@ -207,7 +345,7 @@ func (c *Config) migrateReport(ctx context.Context, kyvernoClient kyverno.Interf
 	case v1.EphemeralReport:
 		err := c.Store.EphemeralReports().Create(ctx, &r)
 		if err != nil {
-			klog.Errorf("failed to mirgrate report of kind %s %s: %s", r.GroupVersionKind().String(), r.Name, err)
+			klog.Errorf("failed to migrate report of kind %s %s: %s", r.GroupVersionKind().String(), r.Name, err)
 		}
 		// Update annotation in Kubernetes before deleting so watchers can identify it
 		_, err = kyvernoClient.ReportsV1().EphemeralReports(r.Namespace).Update(ctx, &r, metav1.UpdateOptions{})
@@ -216,6 +354,32 @@ func (c *Config) migrateReport(ctx context.Context, kyvernoClient kyverno.Interf
 		}
 		if err := kyvernoClient.ReportsV1().EphemeralReports(r.Namespace).Delete(ctx, r.Name, metav1.DeleteOptions{}); err != nil {
 			klog.Errorf("failed to delete ephemeral report %s: %s", r.Name, err)
+		}
+	case openreportsv1alpha1.ClusterReport:
+		err := c.Store.ClusterReports().Create(ctx, &r)
+		if err != nil {
+			klog.Errorf("failed to migrate report of kind %s %s: %s", r.GroupVersionKind().String(), r.Name, err)
+		}
+		// Update annotation in Kubernetes before deleting so watchers can identify it
+		_, err = orClient.ClusterReports().Update(ctx, &r, metav1.UpdateOptions{})
+		if err != nil {
+			klog.Errorf("failed to update annotation for report %s: %s", r.Name, err)
+		}
+		if err := orClient.ClusterReports().Delete(ctx, r.Name, metav1.DeleteOptions{}); err != nil {
+			klog.Errorf("failed to delete cluster report %s: %s", r.Name, err)
+		}
+	case openreportsv1alpha1.Report:
+		err := c.Store.Reports().Create(ctx, &r)
+		if err != nil {
+			klog.Errorf("failed to migrate report of kind %s %s: %s", r.GroupVersionKind().String(), r.Name, err)
+		}
+		// Update annotation in Kubernetes before deleting so watchers can identify it
+		_, err = orClient.Reports(r.Namespace).Update(ctx, &r, metav1.UpdateOptions{})
+		if err != nil {
+			klog.Errorf("failed to update annotation for report %s: %s", r.Name, err)
+		}
+		if err := orClient.Reports(r.Namespace).Delete(ctx, r.Name, metav1.DeleteOptions{}); err != nil {
+			klog.Errorf("failed to delete report %s: %s", r.Name, err)
 		}
 	}
 	<-workerChan

--- a/pkg/server/watch.go
+++ b/pkg/server/watch.go
@@ -6,12 +6,12 @@ import (
 	reportsv1 "github.com/kyverno/kyverno/api/reports/v1"
 	"github.com/kyverno/reports-server/pkg/api"
 	storageapi "github.com/kyverno/reports-server/pkg/storage/api"
-	openreportsv1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	watchtools "k8s.io/client-go/tools/watch"
 	"k8s.io/klog/v2"
+	openreportsv1alpha1 "openreports.io/apis/openreports.io/v1alpha1"
 	"sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2"
 )
 

--- a/pkg/server/watch.go
+++ b/pkg/server/watch.go
@@ -5,49 +5,17 @@ import (
 
 	reportsv1 "github.com/kyverno/kyverno/api/reports/v1"
 	"github.com/kyverno/reports-server/pkg/api"
+	storageapi "github.com/kyverno/reports-server/pkg/storage/api"
+	openreportsv1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	watchtools "k8s.io/client-go/tools/watch"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2"
 )
 
-func (c *Config) watchEphr(ctx context.Context, watchIface *watchtools.RetryWatcher) {
-	for {
-		select {
-		case <-ctx.Done():
-		case event := <-watchIface.ResultChan():
-			switch event.Type {
-			case watch.Added:
-				ephr := event.Object.(*reportsv1.EphemeralReport)
-				applyReportsServerAnnotation(ephr)
-				err := c.Store.EphemeralReports().Create(ctx, ephr)
-				if err != nil {
-					klog.Error(err)
-				}
-			case watch.Modified:
-				ephr := event.Object.(*reportsv1.EphemeralReport)
-				applyReportsServerAnnotation(ephr)
-				ephr.Annotations[api.ServedByReportsServerAnnotation] = api.ServedByReportsServerValue
-				err := c.Store.EphemeralReports().Update(ctx, ephr)
-				if err != nil {
-					klog.Error(err)
-				}
-			case watch.Deleted:
-				ephr := event.Object.(*reportsv1.EphemeralReport)
-				// Skip deletion if report was already migrated to the store
-				if ephr.Annotations != nil && ephr.Annotations[api.ServedByReportsServerAnnotation] == api.ServedByReportsServerValue {
-					continue
-				}
-				err := c.Store.EphemeralReports().Delete(ctx, ephr.Name, ephr.Namespace)
-				if err != nil {
-					klog.Error(err)
-				}
-			}
-		}
-	}
-}
-
-func (c *Config) watchCephr(ctx context.Context, watchIface *watchtools.RetryWatcher) {
+func (c *Config) watchReport(ctx context.Context, watchIface *watchtools.RetryWatcher) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -55,102 +23,146 @@ func (c *Config) watchCephr(ctx context.Context, watchIface *watchtools.RetryWat
 		case event := <-watchIface.ResultChan():
 			switch event.Type {
 			case watch.Added:
-				cephr := event.Object.(*reportsv1.ClusterEphemeralReport)
-				applyReportsServerAnnotation(cephr)
-				err := c.Store.ClusterEphemeralReports().Create(ctx, cephr)
-				if err != nil {
-					klog.Error(err)
-				}
+				handleCreate(ctx, c.Store, event.Object)
 			case watch.Modified:
-				cephr := event.Object.(*reportsv1.ClusterEphemeralReport)
-				applyReportsServerAnnotation(cephr)
-				err := c.Store.ClusterEphemeralReports().Update(ctx, cephr)
-				if err != nil {
-					klog.Error(err)
-				}
+				handleUpdate(ctx, c.Store, event.Object)
 			case watch.Deleted:
-				cephr := event.Object.(*reportsv1.ClusterEphemeralReport)
-				// Skip deletion if report was already migrated to the store
-				if cephr.Annotations != nil && cephr.Annotations[api.ServedByReportsServerAnnotation] == api.ServedByReportsServerValue {
-					continue
-				}
-				err := c.Store.ClusterEphemeralReports().Delete(ctx, cephr.Name)
-				if err != nil {
-					klog.Error(err)
-				}
+				handleDelete(ctx, c.Store, event.Object)
 			}
 		}
 	}
 }
 
-func (c *Config) watchPolr(ctx context.Context, watchIface *watchtools.RetryWatcher) {
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case event := <-watchIface.ResultChan():
-			switch event.Type {
-			case watch.Added:
-				polr := event.Object.(*v1alpha2.PolicyReport)
-				applyReportsServerAnnotation(polr)
-				err := c.Store.PolicyReports().Create(ctx, polr)
-				if err != nil {
-					klog.Error(err)
-				}
-			case watch.Modified:
-				polr := event.Object.(*v1alpha2.PolicyReport)
-				applyReportsServerAnnotation(polr)
-				err := c.Store.PolicyReports().Update(ctx, polr)
-				if err != nil {
-					klog.Error(err)
-				}
-			case watch.Deleted:
-				polr := event.Object.(*v1alpha2.PolicyReport)
-				// Skip deletion if report was already migrated to the store
-				if polr.Annotations != nil && polr.Annotations[api.ServedByReportsServerAnnotation] == api.ServedByReportsServerValue {
-					continue
-				}
-				err := c.Store.PolicyReports().Delete(ctx, polr.Name, polr.Namespace)
-				if err != nil {
-					klog.Error(err)
-				}
-			}
+func handleUpdate(ctx context.Context, storageIface storageapi.Storage, obj runtime.Object) {
+	switch report := obj.(type) {
+	case *v1alpha2.ClusterPolicyReport:
+		applyReportsServerAnnotation(report)
+		err := storageIface.ClusterPolicyReports().Update(ctx, report)
+		if err != nil {
+			klog.Error(err)
+		}
+	case *v1alpha2.PolicyReport:
+		applyReportsServerAnnotation(report)
+		err := storageIface.PolicyReports().Update(ctx, report)
+		if err != nil {
+			klog.Error(err)
+		}
+	case *reportsv1.ClusterEphemeralReport:
+		applyReportsServerAnnotation(report)
+		err := storageIface.ClusterEphemeralReports().Update(ctx, report)
+		if err != nil {
+			klog.Error(err)
+		}
+	case *reportsv1.EphemeralReport:
+		applyReportsServerAnnotation(report)
+		err := storageIface.EphemeralReports().Update(ctx, report)
+		if err != nil {
+			klog.Error(err)
+		}
+	case *openreportsv1alpha1.Report:
+		applyReportsServerAnnotation(report)
+		err := storageIface.Reports().Update(ctx, report)
+		if err != nil {
+			klog.Error(err)
+		}
+	case *openreportsv1alpha1.ClusterReport:
+		applyReportsServerAnnotation(report)
+		err := storageIface.ClusterReports().Update(ctx, report)
+		if err != nil {
+			klog.Error(err)
 		}
 	}
 }
 
-func (c *Config) watchCpolr(ctx context.Context, watchIface *watchtools.RetryWatcher) {
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case event := <-watchIface.ResultChan():
-			switch event.Type {
-			case watch.Added:
-				cpolr := event.Object.(*v1alpha2.ClusterPolicyReport)
-				applyReportsServerAnnotation(cpolr)
-				err := c.Store.ClusterPolicyReports().Create(ctx, cpolr)
-				if err != nil {
-					klog.Error(err)
-				}
-			case watch.Modified:
-				cpolr := event.Object.(*v1alpha2.ClusterPolicyReport)
-				applyReportsServerAnnotation(cpolr)
-				err := c.Store.ClusterPolicyReports().Update(ctx, cpolr)
-				if err != nil {
-					klog.Error(err)
-				}
-			case watch.Deleted:
-				cpolr := event.Object.(*v1alpha2.ClusterPolicyReport)
-				// Skip deletion if report was already migrated to the store
-				if cpolr.Annotations != nil && cpolr.Annotations[api.ServedByReportsServerAnnotation] == api.ServedByReportsServerValue {
-					continue
-				}
-				err := c.Store.ClusterPolicyReports().Delete(ctx, cpolr.Name)
-				if err != nil {
-					klog.Error(err)
-				}
-			}
+func handleCreate(ctx context.Context, storageIface storageapi.Storage, obj runtime.Object) {
+	switch report := obj.(type) {
+	case *v1alpha2.ClusterPolicyReport:
+		applyReportsServerAnnotation(report)
+		err := storageIface.ClusterPolicyReports().Create(ctx, report)
+		if err != nil {
+			klog.Error(err)
+		}
+	case *v1alpha2.PolicyReport:
+		applyReportsServerAnnotation(report)
+		err := storageIface.PolicyReports().Create(ctx, report)
+		if err != nil {
+			klog.Error(err)
+		}
+	case *reportsv1.ClusterEphemeralReport:
+		applyReportsServerAnnotation(report)
+		err := storageIface.ClusterEphemeralReports().Create(ctx, report)
+		if err != nil {
+			klog.Error(err)
+		}
+	case *reportsv1.EphemeralReport:
+		applyReportsServerAnnotation(report)
+		err := storageIface.EphemeralReports().Create(ctx, report)
+		if err != nil {
+			klog.Error(err)
+		}
+	case *openreportsv1alpha1.Report:
+		applyReportsServerAnnotation(report)
+		err := storageIface.Reports().Create(ctx, report)
+		if err != nil {
+			klog.Error(err)
+		}
+	case *openreportsv1alpha1.ClusterReport:
+		applyReportsServerAnnotation(report)
+		err := storageIface.ClusterReports().Create(ctx, report)
+		if err != nil {
+			klog.Error(err)
+		}
+	}
+}
+
+func handleDelete(ctx context.Context, storageIface storageapi.Storage, obj runtime.Object) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		klog.Error(err)
+		return
+	}
+
+	annotations := accessor.GetAnnotations()
+	if annotations != nil && annotations[api.ServedByReportsServerAnnotation] == api.ServedByReportsServerValue {
+		return
+	}
+
+	switch report := obj.(type) {
+	case *v1alpha2.ClusterPolicyReport:
+		applyReportsServerAnnotation(report)
+		err := storageIface.ClusterPolicyReports().Delete(ctx, report.Name)
+		if err != nil {
+			klog.Error(err)
+		}
+	case *v1alpha2.PolicyReport:
+		applyReportsServerAnnotation(report)
+		err := storageIface.PolicyReports().Delete(ctx, report.Name, report.Namespace)
+		if err != nil {
+			klog.Error(err)
+		}
+	case *reportsv1.ClusterEphemeralReport:
+		applyReportsServerAnnotation(report)
+		err := storageIface.ClusterEphemeralReports().Delete(ctx, report.Name)
+		if err != nil {
+			klog.Error(err)
+		}
+	case *reportsv1.EphemeralReport:
+		applyReportsServerAnnotation(report)
+		err := storageIface.EphemeralReports().Delete(ctx, report.Name, report.Namespace)
+		if err != nil {
+			klog.Error(err)
+		}
+	case *openreportsv1alpha1.Report:
+		applyReportsServerAnnotation(report)
+		err := storageIface.Reports().Delete(ctx, report.Name, report.Namespace)
+		if err != nil {
+			klog.Error(err)
+		}
+	case *openreportsv1alpha1.ClusterReport:
+		applyReportsServerAnnotation(report)
+		err := storageIface.ClusterReports().Delete(ctx, report.Name)
+		if err != nil {
+			klog.Error(err)
 		}
 	}
 }

--- a/pkg/storage/api/interface.go
+++ b/pkg/storage/api/interface.go
@@ -5,7 +5,7 @@ import (
 
 	reportsv1 "github.com/kyverno/kyverno/api/reports/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	openreportsv1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
+	openreportsv1alpha1 "openreports.io/apis/openreports.io/v1alpha1"
 	"sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2"
 )
 

--- a/pkg/storage/api/interface.go
+++ b/pkg/storage/api/interface.go
@@ -5,7 +5,7 @@ import (
 
 	reportsv1 "github.com/kyverno/kyverno/api/reports/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	openreportsv1alpha1 "openreports.io/apis/openreports.io/v1alpha1"
+	openreportsv1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
 	"sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2"
 )
 
@@ -25,6 +25,7 @@ type GenericIface[T metav1.Object] interface {
 	Create(ctx context.Context, obj T) error
 	Update(ctx context.Context, obj T) error
 	Delete(ctx context.Context, name, ns string) error
+	Count(ctx context.Context) (int, error)
 	UseResourceVersion() string
 	SetResourceVersion(string) error
 }
@@ -35,6 +36,7 @@ type GenericClusterIface[T metav1.Object] interface {
 	Create(ctx context.Context, obj T) error
 	Update(ctx context.Context, obj T) error
 	Delete(ctx context.Context, name string) error
+	Count(ctx context.Context) (int, error)
 	UseResourceVersion() string
 	SetResourceVersion(string) error
 }

--- a/pkg/storage/db/generic.go
+++ b/pkg/storage/db/generic.go
@@ -135,3 +135,16 @@ func (c *genericGetter[T, PT]) Delete(ctx context.Context, name, ns string) erro
 	}
 	return nil
 }
+
+func (c *genericGetter[T, PT]) Count(ctx context.Context) (int, error) {
+	var count int
+	err := c.db.QueryRowContext(
+		ctx,
+		fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE cluster_id = $1", c.tableName),
+		c.clusterUID,
+	).Scan(&count)
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}

--- a/pkg/storage/db/generic_clustered.go
+++ b/pkg/storage/db/generic_clustered.go
@@ -129,3 +129,16 @@ func (c *genericClusterGetter[T, PT]) Delete(ctx context.Context, name string) e
 	}
 	return nil
 }
+
+func (c *genericClusterGetter[T, PT]) Count(ctx context.Context) (int, error) {
+	var count int
+	err := c.db.QueryRowContext(
+		ctx,
+		fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE cluster_id = $1", c.tableName),
+		c.clusterUID,
+	).Scan(&count)
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}

--- a/pkg/storage/etcd/store.go
+++ b/pkg/storage/etcd/store.go
@@ -164,6 +164,10 @@ func (o *objectStoreNamespaced[T]) Delete(ctx context.Context, name, namespace s
 	return nil
 }
 
+func (o *objectStoreNamespaced[T]) Count(ctx context.Context) (int, error) {
+	return 0, fmt.Errorf("count not implemented for etcd objectStoreNamespaced")
+}
+
 type ObjectStorageCluster[T metav1.Object] interface {
 	Get(ctx context.Context, name string) (T, error)
 	List(ctx context.Context) ([]T, error)
@@ -205,6 +209,10 @@ func (o *objectStoreCluster[T]) Update(ctx context.Context, obj T) error {
 
 func (o *objectStoreCluster[T]) Delete(ctx context.Context, name string) error {
 	return o.store.Delete(ctx, name, "")
+}
+
+func (o *objectStoreCluster[T]) Count(ctx context.Context) (int, error) {
+	return o.store.Count(ctx)
 }
 
 func (o *objectStoreCluster[T]) SetResourceVersion(val string) error {

--- a/pkg/storage/inmemory/client.go
+++ b/pkg/storage/inmemory/client.go
@@ -6,7 +6,7 @@ import (
 	reportsv1 "github.com/kyverno/kyverno/api/reports/v1"
 	storageapi "github.com/kyverno/reports-server/pkg/storage/api"
 	"github.com/kyverno/reports-server/pkg/utils"
-	openreportsv1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
+	openreportsv1alpha1 "openreports.io/apis/openreports.io/v1alpha1"
 	"sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2"
 )
 

--- a/pkg/storage/inmemory/client.go
+++ b/pkg/storage/inmemory/client.go
@@ -6,7 +6,7 @@ import (
 	reportsv1 "github.com/kyverno/kyverno/api/reports/v1"
 	storageapi "github.com/kyverno/reports-server/pkg/storage/api"
 	"github.com/kyverno/reports-server/pkg/utils"
-	openreportsv1alpha1 "openreports.io/apis/openreports.io/v1alpha1"
+	openreportsv1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
 	"sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2"
 )
 

--- a/pkg/storage/inmemory/generic.go
+++ b/pkg/storage/inmemory/generic.go
@@ -118,6 +118,12 @@ func (c *genericClusterInMemStore[T, PT]) Delete(ctx context.Context, name strin
 	}
 }
 
+func (g *genericClusterInMemStore[T, PT]) Count(ctx context.Context) (int, error) {
+	g.Lock()
+	defer g.Unlock()
+	return len(g.db), nil
+}
+
 type genericInMemStore[T any, PT interface {
 	*T
 	metav1.Object
@@ -225,4 +231,10 @@ func (g *genericInMemStore[T, PT]) Delete(ctx context.Context, name, namespace s
 	delete(g.db, key)
 	klog.Infof("entry deleted for key:%s", key)
 	return nil
+}
+
+func (g *genericInMemStore[T, PT]) Count(ctx context.Context) (int, error) {
+	g.Lock()
+	defer g.Unlock()
+	return len(g.db), nil
 }


### PR DESCRIPTION
## Explanation

- when an instance of the reports server starts it attempts to migrate reports from the apiserver to the database anyways, which if ran in a cluster that previously had this migration run would cause the api to be down for the duration of the migration when its not even needed.
- make migrations conditional on a mismatch in the count between reports in the db and what the apiserver says it has.
- handle missing openreports migration during start.
- refactor the migration() function to branch to different handlers per api to avoid having one very long function.
- make the watch functions generic and add missing openreports conditions.
- add the Count function to the storage interface to fetch the count of reports in a table to avoid expensive database queries.
- implement this function on the postgres and in memory storage types.

## Related issue

Closes https://github.com/kyverno/reports-server/issues/323