### PR TITLE
feat: add leader election to control when apiservices get cleaned up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Session.vim
 *manifest-tool
 .gopath
 .tools
+.DS_Store

--- a/charts/reports-server/templates/cluster-roles.yaml
+++ b/charts/reports-server/templates/cluster-roles.yaml
@@ -23,6 +23,14 @@ rules:
     - watch
     - deletecollection
 - apiGroups:
+    - "coordination.k8s.io"
+  resources:
+    - "leases"
+  verbs:
+    - "create"
+    - "get"
+    - "update"
+- apiGroups:
     - ""
   resources:
     - namespaces

--- a/charts/reports-server/templates/deployment.yaml
+++ b/charts/reports-server/templates/deployment.yaml
@@ -80,6 +80,12 @@ spec:
               {{- include "reports-server.dbUser" . | nindent 14 }}
             - name: DB_PASSWORD
               {{- include "reports-server.dbPassword" . | nindent 14 }}
+            - name: HEADLESS_SERVICE
+              value: {{ include "reports-server.fullname" . }}-headless.svc.cluster.local
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           {{- with $env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/reports-server/templates/deployment.yaml
+++ b/charts/reports-server/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
             - name: DB_PASSWORD
               {{- include "reports-server.dbPassword" . | nindent 14 }}
             - name: HEADLESS_SERVICE
-              value: {{ include "reports-server.fullname" . }}-headless.svc.cluster.local
+              value: {{ include "reports-server.fullname" . }}-headless.{{ $.Release.Namespace }}.svc.cluster.local
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/charts/reports-server/templates/service-hl.yaml
+++ b/charts/reports-server/templates/service-hl.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "reports-server.fullname" . }}-headless
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "reports-server.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: https
+    port: {{ .Values.service.port }}
+    protocol: TCP
+    targetPort: https
+  selector:
+    {{- include "reports-server.selectorLabels" . | nindent 4 }}

--- a/config/install-etcd.yaml
+++ b/config/install-etcd.yaml
@@ -62,6 +62,14 @@ rules:
     - watch
     - deletecollection
 - apiGroups:
+    - "coordination.k8s.io"
+  resources:
+    - "leases"
+  verbs:
+    - "create"
+    - "get"
+    - "update"
+- apiGroups:
     - ""
   resources:
     - namespaces
@@ -241,6 +249,29 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: reports-server-headless
+  namespace: reports-server
+  labels:
+    helm.sh/chart: reports-server-0.1.6
+    app.kubernetes.io/name: reports-server
+    app.kubernetes.io/instance: reports-server
+    app.kubernetes.io/version: "v0.1.6"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: https
+  selector:
+    app.kubernetes.io/name: reports-server
+    app.kubernetes.io/instance: reports-server
+---
+apiVersion: v1
+kind: Service
+metadata:
   name: reports-server
   namespace: reports-server
   labels:
@@ -324,6 +355,12 @@ spec:
               value: "postgres"
             - name: DB_PASSWORD
               value: "reports"
+            - name: HEADLESS_SERVICE
+              value: reports-server-headless.reports-server.svc.cluster.local
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -91,6 +91,14 @@ rules:
     - watch
     - deletecollection
 - apiGroups:
+    - "coordination.k8s.io"
+  resources:
+    - "leases"
+  verbs:
+    - "create"
+    - "get"
+    - "update"
+- apiGroups:
     - ""
   resources:
     - namespaces
@@ -303,6 +311,29 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: reports-server-headless
+  namespace: reports-server
+  labels:
+    helm.sh/chart: reports-server-0.1.6
+    app.kubernetes.io/name: reports-server
+    app.kubernetes.io/instance: reports-server
+    app.kubernetes.io/version: "v0.1.6"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: https
+  selector:
+    app.kubernetes.io/name: reports-server
+    app.kubernetes.io/instance: reports-server
+---
+apiVersion: v1
+kind: Service
+metadata:
   name: reports-server
   namespace: reports-server
   labels:
@@ -387,6 +418,12 @@ spec:
               value: "postgres"
             - name: DB_PASSWORD
               value: "reports"
+            - name: HEADLESS_SERVICE
+              value: reports-server-headless.reports-server.svc.cluster.local
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/pkg/app/policyserver.go
+++ b/pkg/app/policyserver.go
@@ -168,10 +168,12 @@ func runCommand(o *opts.Options, stopCh <-chan struct{}) error {
 
 	// wait on shutdown signal
 	<-stopCh
+	klog.Info("received shutdown signal")
 
 	// wait on the cleanup to finish only if this was the leader
 	if wasLeader.Load() {
 		<-reconcilerDone
+		klog.Info("cleanup completed")
 	}
 
 	return nil

--- a/pkg/app/policyserver.go
+++ b/pkg/app/policyserver.go
@@ -130,7 +130,6 @@ func runCommand(o *opts.Options, stopCh <-chan struct{}) error {
 
 				<-stopCh
 				reconcilerCancel()
-				<-reconcilerDone
 
 				resolver := net.Resolver{}
 				addrs, err := resolver.LookupHost(ctx, headlessSvc)

--- a/pkg/app/policyserver.go
+++ b/pkg/app/policyserver.go
@@ -15,7 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
-
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 	"k8s.io/component-base/term"
@@ -133,7 +132,8 @@ func runCommand(o *opts.Options, stopCh <-chan struct{}) error {
 				reconcilerCancel()
 				<-reconcilerDone
 
-				addrs, err := net.LookupHost(headlessSvc)
+				resolver := net.Resolver{}
+				addrs, err := resolver.LookupHost(ctx, headlessSvc)
 				if err != nil {
 					klog.Errorf("error looking up headless service dns name: %s, %s", headlessSvc, err.Error())
 				}
@@ -155,7 +155,6 @@ func runCommand(o *opts.Options, stopCh <-chan struct{}) error {
 					}
 				}
 				close(reconcilerDone)
-
 			},
 			OnStoppedLeading: func() {
 				wasLeader.Store(false)

--- a/pkg/app/policyserver.go
+++ b/pkg/app/policyserver.go
@@ -4,13 +4,18 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
 	"os"
-	"os/signal"
-	"syscall"
+	"sync/atomic"
+	"time"
 
 	"github.com/kyverno/reports-server/pkg/app/opts"
 	"github.com/kyverno/reports-server/pkg/server"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 	"k8s.io/component-base/term"
@@ -64,11 +69,21 @@ func runCommand(o *opts.Options, stopCh <-chan struct{}) error {
 	if len(errors) > 0 {
 		return errors[0]
 	}
+
+	podIp := os.Getenv("POD_IP")
+	if podIp == "" {
+		podIp, _ = os.Hostname()
+	}
+
+	headlessSvc := os.Getenv("HEADLESS_SERVICE")
+	if headlessSvc == "" {
+		klog.Error("no headless service dns name found. api service cleanup during leader shutdown will not work properly")
+	}
+
 	config, err := server.NewServerConfig(*o)
 	if err != nil {
 		return err
 	}
-
 	s, err := config.Complete()
 	if err != nil {
 		return err
@@ -80,28 +95,84 @@ func runCommand(o *opts.Options, stopCh <-chan struct{}) error {
 		}
 	}()
 
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Name:      "reports-server-leader",
+			Namespace: "kube-system",
+		},
+		Client: config.KubeClient.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: podIp,
+		},
+	}
+
 	reconcilerCtx, reconcilerCancel := context.WithCancel(context.Background())
 	reconcilerDone := make(chan struct{})
-	go func() {
-		config.StartAPIServiceReconciler(reconcilerCtx)
-		close(reconcilerDone)
-	}()
+	var wasLeader atomic.Bool
 
-	sigChan := make(chan os.Signal, 1)
-	done := make(chan bool, 1)
+	go leaderelection.RunOrDie(context.Background(), leaderelection.LeaderElectionConfig{
+		Lock:            lock,
+		LeaseDuration:   15 * time.Second,
+		RenewDeadline:   10 * time.Second,
+		RetryPeriod:     2 * time.Second,
+		ReleaseOnCancel: true,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(ctx context.Context) {
+				wasLeader.Store(true)
+				go func() {
+					select {
+					//  OnStoppedLeading ran first and cancelled the context. replace it with a new one
+					case <-reconcilerCtx.Done():
+						reconcilerCtx, reconcilerCancel = context.WithCancel(context.Background())
+					default:
+					}
+					config.StartAPIServiceReconciler(reconcilerCtx)
+				}()
 
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+				<-stopCh
+				reconcilerCancel()
+				<-reconcilerDone
 
-	go func() {
-		<-sigChan
-		reconcilerCancel()
+				addrs, err := net.LookupHost(headlessSvc)
+				if err != nil {
+					klog.Errorf("error looking up headless service dns name: %s, %s", headlessSvc, err.Error())
+				}
+
+				// check if this is the only pod remaining
+				otherReplicasExist := false
+				for _, a := range addrs {
+					if a == podIp {
+						continue
+					}
+					// there's an address and its not that of the current pod
+					otherReplicasExist = true
+				}
+
+				// if its, clean up the apiservices (convert to local) on shutdown
+				if !otherReplicasExist {
+					if err := config.CleanupApiServices(); err != nil {
+						klog.ErrorS(err, "failed to cleanup api-services during shutdown")
+					}
+				}
+				close(reconcilerDone)
+
+			},
+			OnStoppedLeading: func() {
+				wasLeader.Store(false)
+				reconcilerCancel()
+			},
+			OnNewLeader: func(identity string) {
+			},
+		},
+	})
+
+	// wait on shutdown signal
+	<-stopCh
+
+	// wait on the cleanup to finish only if this was the leader
+	if wasLeader.Load() {
 		<-reconcilerDone
-		if err := config.CleanupApiServices(); err != nil {
-			klog.ErrorS(err, "failed to cleanup api-services during shutdown")
-		}
-		done <- true
-	}()
+	}
 
-	<-done
 	return nil
 }

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	Store                       storageapi.Storage
 	SkipMigration               bool
 	APIServiceReconcileInterval time.Duration
+	KubeClient                  *kubernetes.Clientset
 }
 
 func NewServerConfig(o opts.Options) (*Config, error) {
@@ -92,6 +93,7 @@ func NewServerConfig(o opts.Options) (*Config, error) {
 		Rest:                        restConfig,
 		Embedded:                    o.Etcd,
 		EtcdConfig:                  &o.EtcdConfig,
+		KubeClient:                  client,
 		DBconfig:                    dbconfig,
 		ClusterName:                 o.ClusterName,
 		APIServices:                 apiservices,


### PR DESCRIPTION
- make the cleanup of apiservices and the apiservice reconciler gated on the current instance being the leader.
- make the cleanup logic not run except if the leader died and was the only pod to avoid flipping the apiservices to local if there are other replicas.
- start a pod ip based leader election.
- create a headless service as a part of the helm chart to make pods.
- add rbac access to leases.
- make the kubernetes clientset part of the config struct to make it reusable.