### PR TITLE
fix(etcd): initialize ResourceVersion in NewObjectStoreCluster (#352)

### DIFF
--- a/pkg/storage/etcd/store.go
+++ b/pkg/storage/etcd/store.go
@@ -183,10 +183,11 @@ type objectStoreCluster[T metav1.Object] struct {
 func NewObjectStoreCluster[T metav1.Object](client clientv3.KV, gvk schema.GroupVersionKind, gr schema.GroupResource) api.GenericClusterIface[T] {
 	return &objectStoreCluster[T]{
 		store: &objectStoreNamespaced[T]{
-			namespaced: false,
-			etcdclient: client,
-			gvk:        gvk,
-			gr:         gr,
+			ResourceVersion: versioning.NewVersioning(),
+			namespaced:      false,
+			etcdclient:      client,
+			gvk:             gvk,
+			gr:              gr,
 		},
 	}
 }

--- a/pkg/storage/etcd/store_test.go
+++ b/pkg/storage/etcd/store_test.go
@@ -1,0 +1,26 @@
+package etcd
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// TestClusterStoreUseResourceVersionNoPanic guards against a regression where
+// NewObjectStoreCluster left the embedded *versioning.ResourceVersion nil. The
+// first call to UseResourceVersion (made during Create of a cluster-scoped
+// report) then dereferenced that nil pointer and panicked, taking down the
+// apiserver request handler. See kyverno/reports-server#352.
+func TestClusterStoreUseResourceVersionNoPanic(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "wgpolicyk8s.io", Version: "v1alpha2", Kind: "ClusterPolicyReport"}
+	gr := schema.GroupResource{Group: "wgpolicyk8s.io", Resource: "clusterpolicyreports"}
+
+	// A nil KV client is fine: UseResourceVersion only touches the in-memory
+	// versioning struct and never talks to etcd.
+	store := NewObjectStoreCluster[metav1.Object](nil, gvk, gr)
+
+	if got := store.UseResourceVersion(); got == "" {
+		t.Fatalf("expected a non-empty resource version, got %q", got)
+	}
+}

--- a/pkg/storage/etcd/store_test.go
+++ b/pkg/storage/etcd/store_test.go
@@ -7,11 +7,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// TestClusterStoreUseResourceVersionNoPanic guards against a regression where
-// NewObjectStoreCluster left the embedded *versioning.ResourceVersion nil. The
-// first call to UseResourceVersion (made during Create of a cluster-scoped
-// report) then dereferenced that nil pointer and panicked, taking down the
-// apiserver request handler. See kyverno/reports-server#352.
 func TestClusterStoreUseResourceVersionNoPanic(t *testing.T) {
 	gvk := schema.GroupVersionKind{Group: "wgpolicyk8s.io", Version: "v1alpha2", Kind: "ClusterPolicyReport"}
 	gr := schema.GroupResource{Group: "wgpolicyk8s.io", Resource: "clusterpolicyreports"}


### PR DESCRIPTION
Fixes #352.

Creating any cluster-scoped report against the etcd backend panics the apiserver with a nil pointer dereference. The cluster store wraps an `objectStoreNamespaced` whose embedded `*versioning.ResourceVersion` is left nil, so the first `UseResourceVersion()` call during Create dereferences nil. The stack lands at versioning/versioning.go:33 via etcd/store.go:223, which matches the trace in the issue. The namespaced constructor already sets this field; the cluster one just forgot. Fix is to add `ResourceVersion: versioning.NewVersioning()` in `NewObjectStoreCluster`, same as the namespaced path.

Added a small regression test that calls `NewObjectStoreCluster(...).UseResourceVersion()` (a nil KV client is fine, that path only touches the in-memory versioning struct). It panics before the fix and passes after.

@aerosouund you said on the issue you'd leave a fix to whoever picked it up, so here's one. Happy to move or rename the test if you'd prefer it elsewhere. Thanks!
